### PR TITLE
Java7 upgrade and syntax cleanup.

### DIFF
--- a/mango-core/src/main/java/org/calrissian/mango/batch/BatcherBuilder.java
+++ b/mango-core/src/main/java/org/calrissian/mango/batch/BatcherBuilder.java
@@ -111,13 +111,13 @@ public final class BatcherBuilder {
         BlockingQueue<T> backingQueue = (maxBufferSize == UNSET_INT ? new LinkedBlockingQueue<T>() : new ArrayBlockingQueue<T>(maxBufferSize));
 
         if (maxSize != UNSET_INT && interval != UNSET_INT) {
-            return new TimeOrSizeBatcher<T>(backingQueue, listener, handler, maxSize, interval)
+            return new TimeOrSizeBatcher<>(backingQueue, listener, handler, maxSize, interval)
                     .start();
         } else if (maxSize != UNSET_INT) {
-            return new SizeBatcher<T>(backingQueue, listener, handler, maxSize)
+            return new SizeBatcher<>(backingQueue, listener, handler, maxSize)
                     .start();
         } else {
-            return new TimeBatcher<T>(backingQueue, listener, handler, interval)
+            return new TimeBatcher<>(backingQueue, listener, handler, interval)
                     .start();
         }
     }
@@ -133,7 +133,7 @@ public final class BatcherBuilder {
 
         @Override
         protected Collection<T> generateBatch(BlockingQueue<T> backingQueue) throws InterruptedException {
-            Collection<T> batch = new ArrayList<T>(maxSize);
+            Collection<T> batch = new ArrayList<>(maxSize);
 
             int remainingSize = maxSize;
 
@@ -162,7 +162,7 @@ public final class BatcherBuilder {
 
         @Override
         protected Collection<T> generateBatch(BlockingQueue<T> backingQueue) throws InterruptedException {
-            Collection<T> batch = new ArrayList<T>();
+            Collection<T> batch = new ArrayList<>();
 
             long startTime = nanoTime();
             long remainingTime = interval;
@@ -199,7 +199,7 @@ public final class BatcherBuilder {
 
         @Override
         protected Collection<T> generateBatch(BlockingQueue<T> backingQueue) throws InterruptedException {
-            Collection<T> batch = new ArrayList<T>(maxSize);
+            Collection<T> batch = new ArrayList<>(maxSize);
 
             long startTime = nanoTime();
             long remainingTime = interval;

--- a/mango-core/src/main/java/org/calrissian/mango/collect/CloseableIterables.java
+++ b/mango-core/src/main/java/org/calrissian/mango/collect/CloseableIterables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -195,6 +195,7 @@ public class CloseableIterables {
      * of each iterable in {@code inputs}. The input iterators are not polled until
      * necessary.
      */
+    @SafeVarargs
     public static <T> CloseableIterable<T> chain(CloseableIterable<? extends T>... iterables) {
         return chain(asList(iterables));
     }
@@ -260,6 +261,7 @@ public class CloseableIterables {
      * <p>The equivalent of this method is {@link
      * java.util.Collections#emptySet()}.
      */
+    @SuppressWarnings("unchecked")
     public static <T> CloseableIterable<T> emptyIterable() {
         return EMPTY_ITERABLE;
     }

--- a/mango-core/src/main/java/org/calrissian/mango/collect/CloseableIterators.java
+++ b/mango-core/src/main/java/org/calrissian/mango/collect/CloseableIterators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,6 +206,7 @@ public class CloseableIterators {
      * iterator.  A call to close on the returned closeable iterator will quietly close all of
      * the closeable iterators in {@code inputs} which have not been exhausted.
      */
+    @SafeVarargs
     public static <T> CloseableIterator<T> chain(CloseableIterator<? extends T>... iterators) {
         return chain(Iterators.forArray(iterators));
     }

--- a/mango-core/src/main/java/org/calrissian/mango/collect/Iterators2.java
+++ b/mango-core/src/main/java/org/calrissian/mango/collect/Iterators2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ public class Iterators2 {
                     return endOfData();
 
                 Object key = groupingFunction.apply(peekingIterator.peek());
-                List<T> group = new ArrayList<T>();
+                List<T> group = new ArrayList<>();
 
                 do {
                     group.add(peekingIterator.next());

--- a/mango-core/src/main/java/org/calrissian/mango/criteria/domain/AbstractKeyValueLeaf.java
+++ b/mango-core/src/main/java/org/calrissian/mango/criteria/domain/AbstractKeyValueLeaf.java
@@ -15,8 +15,6 @@
  */
 package org.calrissian.mango.criteria.domain;
 
-import com.google.common.collect.AbstractIterator;
-
 public abstract class AbstractKeyValueLeaf extends Leaf {
     private static final long serialVersionUID = 1L;
 

--- a/mango-core/src/main/java/org/calrissian/mango/criteria/domain/ParentNode.java
+++ b/mango-core/src/main/java/org/calrissian/mango/criteria/domain/ParentNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public abstract class ParentNode implements Node {
     protected ParentNode parent;
 
     public ParentNode() {
-        nodes = new ArrayList<Node>();
+        nodes = new ArrayList<>();
     }
 
     public ParentNode(ParentNode parent, List<Node> nodes) {
@@ -90,7 +90,6 @@ public abstract class ParentNode implements Node {
 
     @Override
     public int hashCode() {
-        int result = nodes != null ? nodes.hashCode() : 0;
-        return result;
+        return nodes != null ? nodes.hashCode() : 0;
     }
 }

--- a/mango-core/src/main/java/org/calrissian/mango/criteria/domain/criteria/GreaterThanEqualsCriteria.java
+++ b/mango-core/src/main/java/org/calrissian/mango/criteria/domain/criteria/GreaterThanEqualsCriteria.java
@@ -36,8 +36,9 @@ public class GreaterThanEqualsCriteria extends ComparableKeyValueLeafCriteria {
     public boolean apply(TupleStore obj) {
         Collection<Tuple> tuples = obj.getAll(key);
         if (tuples != null) {
-            for (Tuple tuple : tuples)
+            for (Tuple tuple : tuples) {
                 return comparator.compare(tuple.getValue(), value) >= 0;
+            }
         }
 
         return false;

--- a/mango-core/src/main/java/org/calrissian/mango/criteria/domain/criteria/ParentCriteria.java
+++ b/mango-core/src/main/java/org/calrissian/mango/criteria/domain/criteria/ParentCriteria.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ public abstract class ParentCriteria implements Criteria {
     protected ParentCriteria parent;
 
     public ParentCriteria() {
-        nodes = new ArrayList<Criteria>();
+        nodes = new ArrayList<>();
     }
 
     public ParentCriteria(ParentCriteria parent, List<Criteria> nodes) {
@@ -39,7 +39,7 @@ public abstract class ParentCriteria implements Criteria {
 
     public ParentCriteria(ParentCriteria parent) {
         this.parent = parent;
-        this.nodes = new ArrayList<Criteria>();
+        this.nodes = new ArrayList<>();
     }
 
 

--- a/mango-core/src/main/java/org/calrissian/mango/criteria/support/NodeUtils.java
+++ b/mango-core/src/main/java/org/calrissian/mango/criteria/support/NodeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ public class NodeUtils {
 
     private static Criteria criteriaFromNode(Node node, Comparator rangeComparator, ParentCriteria parent) {
 
-        Criteria curNode = null;
+        Criteria curNode;
 
         if (node instanceof AndNode)
             curNode = new AndCriteria(parent);
@@ -113,7 +113,7 @@ public class NodeUtils {
             return new GreaterThanCriteria(leaf.getKey(), leaf.getValue(), rangeComparator, parent);
         else if (node instanceof GreaterThanEqualsLeaf)
             return new GreaterThanEqualsCriteria(leaf.getKey(), leaf.getValue(), rangeComparator, parent);
-        else if (node instanceof RangeCriteria) {
+        else if (node instanceof RangeLeaf) {
             RangeLeaf rangeLeaf = (RangeLeaf) leaf;
             return new RangeCriteria(leaf.getKey(), leaf.getValue(), rangeLeaf.getEnd(), rangeComparator, parent);
         } else

--- a/mango-core/src/main/java/org/calrissian/mango/criteria/visitor/PrintNodeVisitor.java
+++ b/mango-core/src/main/java/org/calrissian/mango/criteria/visitor/PrintNodeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ public class PrintNodeVisitor implements NodeVisitor {
         write("),");
         try {
             writer.flush();
-        } catch (IOException e) {
+        } catch (IOException ignored) {
         }
     }
 
@@ -58,7 +58,7 @@ public class PrintNodeVisitor implements NodeVisitor {
             write(node.getClass().getSimpleName() + ",");
         try {
             writer.flush();
-        } catch (IOException e) {
+        } catch (IOException ignored) {
         }
     }
 
@@ -78,7 +78,7 @@ public class PrintNodeVisitor implements NodeVisitor {
         try {
             writer.write(contents);
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 }

--- a/mango-core/src/main/java/org/calrissian/mango/criteria/visitor/SingleClauseCollapseVisitor.java
+++ b/mango-core/src/main/java/org/calrissian/mango/criteria/visitor/SingleClauseCollapseVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,6 @@ import org.calrissian.mango.criteria.domain.ParentNode;
  * If the parent has only one child, the child can be rolled up into the parent's parent. (if it exists)
  */
 public class SingleClauseCollapseVisitor implements NodeVisitor {
-
-    private boolean wasOptimized = false;
 
     @Override
     public void begin(ParentNode node) {

--- a/mango-core/src/main/java/org/calrissian/mango/domain/BaseTupleStore.java
+++ b/mango-core/src/main/java/org/calrissian/mango/domain/BaseTupleStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,7 +115,7 @@ public class BaseTupleStore implements TupleStore {
     @Override
     public Collection<Tuple> removeAll(Collection<Tuple> tuples) {
         checkNotNull(tuples);
-        Collection<Tuple> removedTuples = new ArrayList<Tuple>();
+        Collection<Tuple> removedTuples = new ArrayList<>();
         for (Tuple tuple : tuples)
             removedTuples.add(remove(tuple));
 

--- a/mango-core/src/main/java/org/calrissian/mango/domain/Tuple.java
+++ b/mango-core/src/main/java/org/calrissian/mango/domain/Tuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ public class Tuple<T> implements Serializable {
 
         this.key = key;
         this.value = value;
-        this.metadata = new HashMap<String, Object>(metadata);
+        this.metadata = new HashMap<>(metadata);
     }
 
     public String getKey() {

--- a/mango-core/src/main/java/org/calrissian/mango/domain/ip/CidrValueRangeIPv4.java
+++ b/mango-core/src/main/java/org/calrissian/mango/domain/ip/CidrValueRangeIPv4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,14 @@ package org.calrissian.mango.domain.ip;
 import com.google.common.collect.Range;
 import org.calrissian.mango.domain.ValueRange;
 
+import static org.calrissian.mango.domain.ip.IPv4.cidrRange;
+
 @Deprecated
 public class CidrValueRangeIPv4 extends ValueRange<IPv4> {
 
     public CidrValueRangeIPv4(String cidrString) {
 
-        Range<IPv4> range = IPv4.cidrRange(cidrString);
+        Range<IPv4> range = cidrRange(cidrString);
 
         setStart(range.lowerEndpoint());
         setStop(range.upperEndpoint());

--- a/mango-core/src/main/java/org/calrissian/mango/hash/tree/MerkleTree.java
+++ b/mango-core/src/main/java/org/calrissian/mango/hash/tree/MerkleTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ public class MerkleTree<T extends HashLeaf> implements Serializable {
      */
     private Node buildTop(List<T> leaves) {
 
-        List<Node> hashNodes = new ArrayList<Node>();
+        List<Node> hashNodes = new ArrayList<>();
         List<T> curLeaves;
         for (int i = 0; i < leaves.size(); i += dimensions) {
             int idx = i + dimensions > leaves.size() ? leaves.size() : i + dimensions;
@@ -107,13 +107,13 @@ public class MerkleTree<T extends HashLeaf> implements Serializable {
      */
     private List<Node> build(List<Node> nodes) {
 
-        List<Node> hashNodes = new ArrayList<Node>();
+        List<Node> hashNodes = new ArrayList<>();
         List<Node> curNodes;
         for (int i = 0; i < nodes.size(); i += dimensions) {
 
             int idx = i + dimensions > nodes.size() ? nodes.size() : i + dimensions;
             curNodes = nodes.subList(i, idx);
-            hashNodes.add(curNodes.size() == 1 ? curNodes.get(0) : new HashNode(new ArrayList<Node>(curNodes)));
+            hashNodes.add(curNodes.size() == 1 ? curNodes.get(0) : new HashNode(new ArrayList<>(curNodes)));
         }
 
         if (hashNodes.size() > 1) {
@@ -139,7 +139,7 @@ public class MerkleTree<T extends HashLeaf> implements Serializable {
         }
 
 
-        List<T> differences = new ArrayList<T>();
+        List<T> differences = new ArrayList<>();
 
         if (!other.getTopHash().getHash().equals(getTopHash().getHash())) {
 
@@ -175,7 +175,7 @@ public class MerkleTree<T extends HashLeaf> implements Serializable {
     @SuppressWarnings("unchecked")
     private List<T> diff(Node one, Node two) {
 
-        List<T> differences = new ArrayList<T>();
+        List<T> differences = new ArrayList<>();
 
         if (!one.getHash().equals(two.getHash())) {
 
@@ -210,7 +210,7 @@ public class MerkleTree<T extends HashLeaf> implements Serializable {
     @SuppressWarnings("unchecked")
     private List<T> getLeaves(List<Node> nodes) {
 
-        List<T> leaves = new ArrayList<T>();
+        List<T> leaves = new ArrayList<>();
         for (Node child : nodes) {
             if (child.getChildren() == null) {
                 leaves.add((T) child);

--- a/mango-core/src/main/java/org/calrissian/mango/io/Serializables.java
+++ b/mango-core/src/main/java/org/calrissian/mango/io/Serializables.java
@@ -60,11 +60,11 @@ public class Serializables {
         return retVal;
     }
 
-    public static final byte[] toBase64(Serializable serializable) throws IOException {
+    public static byte[] toBase64(Serializable serializable) throws IOException {
         return encodeBase64(serialize(serializable));
     }
 
-    public static final <T extends Serializable>T fromBase64(byte[] bytes) throws IOException, ClassNotFoundException {
+    public static <T extends Serializable>T fromBase64(byte[] bytes) throws IOException, ClassNotFoundException {
         return deserialize(decodeBase64(bytes));
     }
 }

--- a/mango-core/src/main/java/org/calrissian/mango/types/LexiTypeEncoders.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/LexiTypeEncoders.java
@@ -39,7 +39,7 @@ public class LexiTypeEncoders {
 
     private LexiTypeEncoders() {/*private constructor*/}
 
-    public static final TypeRegistry<String> LEXI_TYPES = new TypeRegistry<String>(
+    public static final TypeRegistry<String> LEXI_TYPES = new TypeRegistry<>(
             booleanEncoder(), byteEncoder(), dateEncoder(), doubleEncoder(), floatEncoder(),
             integerEncoder(), longEncoder(), stringEncoder(), uriEncoder(), bigIntegerEncoder(),
             bigDecimalEncoder(), inet4AddressEncoder(), inet6AddressEncoder(),
@@ -47,7 +47,7 @@ public class LexiTypeEncoders {
             unsignedIntegerEncoder(), unsignedLongEncoder()
     );
 
-    public static final TypeRegistry<String> LEXI_REV_TYPES = new TypeRegistry<String>(
+    public static final TypeRegistry<String> LEXI_REV_TYPES = new TypeRegistry<>(
             booleanRevEncoder(), byteRevEncoder(), dateRevEncoder(), doubleRevEncoder(), floatRevEncoder(),
             integerRevEncoder(), longRevEncoder(), stringRevEncoder(), uriRevEncoder(), bigIntegerRevEncoder(),
             bigDecimalRevEncoder(), inet4AddressRevEncoder(), inet6AddressRevEncoder(),
@@ -56,7 +56,7 @@ public class LexiTypeEncoders {
     );
 
     private static <T> TypeEncoder<T, String> reverseEncoder(TypeEncoder<T, String> sourceEncoder) {
-        return new ReverseEncoder<T>(sourceEncoder);
+        return new ReverseEncoder<>(sourceEncoder);
     }
 
     public static TypeEncoder<Boolean, String> booleanEncoder() {

--- a/mango-core/src/main/java/org/calrissian/mango/types/SimpleTypeEncoders.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/SimpleTypeEncoders.java
@@ -39,7 +39,7 @@ public class SimpleTypeEncoders {
     private SimpleTypeEncoders() {/* private constructor */}
 
     @SuppressWarnings("unchecked")
-    public static final TypeRegistry<String> SIMPLE_TYPES = new TypeRegistry<String>(
+    public static final TypeRegistry<String> SIMPLE_TYPES = new TypeRegistry<>(
             booleanEncoder(), byteEncoder(), dateEncoder(), doubleEncoder(), floatEncoder(),
             integerEncoder(), longEncoder(), stringEncoder(), uriEncoder(), bigIntegerEncoder(),
             bigDecimalEncoder(), inet4AddressEncoder(), inet6AddressEncoder(),

--- a/mango-core/src/main/java/org/calrissian/mango/types/TypeRegistry.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/TypeRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,8 +41,8 @@ import static java.util.Collections.unmodifiableCollection;
  */
 public class TypeRegistry<U> implements Serializable {
 
-    private final Map<String, TypeEncoder<?, U>> aliasMapping = new LinkedHashMap<String, TypeEncoder<?, U>>();
-    private final Map<Class<?>, TypeEncoder<?, U>> classMapping = new LinkedHashMap<Class<?>, TypeEncoder<?, U>>();
+    private final Map<String, TypeEncoder<?, U>> aliasMapping = new LinkedHashMap<>();
+    private final Map<Class<?>, TypeEncoder<?, U>> classMapping = new LinkedHashMap<>();
 
     public TypeRegistry(TypeEncoder<?, U>... normalizers) {
         this(asList(normalizers));

--- a/mango-core/src/main/java/org/calrissian/mango/types/canonicalizer/CanonicalizerContext.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/canonicalizer/CanonicalizerContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,10 +49,10 @@ public class CanonicalizerContext {
     @SuppressWarnings("unchecked")
     private void loadCanonicalDefs() throws IOException {
 
-        validatorClasses = new HashMap<String, Class<? extends Validator>>();
-        types = new HashMap<String, String>();
-        matchers = new HashMap<String, String>();
-        validators = new HashMap<String, Validator>();
+        validatorClasses = new HashMap<>();
+        types = new HashMap<>();
+        matchers = new HashMap<>();
+        validators = new HashMap<>();
 
         InputStream is = getClass().getClassLoader().getResourceAsStream("validators.properties");
         Properties props = new Properties();
@@ -124,7 +124,7 @@ public class CanonicalizerContext {
 
     public List<CanonicalDef> getCanonicalDefs() {
 
-        List<CanonicalDef> canonicalDefs = new ArrayList<CanonicalDef>();
+        List<CanonicalDef> canonicalDefs = new ArrayList<>();
         for (Map.Entry<String, String> entry : types.entrySet()) {
 
             String type = entry.getKey();

--- a/mango-core/src/main/java/org/calrissian/mango/types/encoders/lexi/Inet4AddressEncoder.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/encoders/lexi/Inet4AddressEncoder.java
@@ -42,9 +42,7 @@ public class Inet4AddressEncoder extends AbstractInet4AddressEncoder<String> {
         checkArgument(value.length() == 8, "The value is not a valid encoding");
         try {
             return (Inet4Address) getByAddress(decodeHex(value.toCharArray()));
-        } catch (UnknownHostException e) {
-            throw new TypeDecodingException(e);
-        } catch (DecoderException e) {
+        } catch (UnknownHostException | DecoderException e) {
             throw new TypeDecodingException(e);
         }
     }

--- a/mango-core/src/main/java/org/calrissian/mango/types/encoders/lexi/Inet4AddressReverseEncoder.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/encoders/lexi/Inet4AddressReverseEncoder.java
@@ -43,9 +43,7 @@ public class Inet4AddressReverseEncoder extends AbstractInet4AddressEncoder<Stri
         checkArgument(value.length() == 8, "The value is not a valid encoding");
         try {
             return (Inet4Address) getByAddress(reverse(decodeHex(value.toCharArray())));
-        } catch (UnknownHostException e) {
-            throw new TypeDecodingException(e);
-        } catch (DecoderException e) {
+        } catch (UnknownHostException | DecoderException e) {
             throw new TypeDecodingException(e);
         }
     }

--- a/mango-core/src/main/java/org/calrissian/mango/types/encoders/lexi/Inet6AddressEncoder.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/encoders/lexi/Inet6AddressEncoder.java
@@ -44,9 +44,7 @@ public class Inet6AddressEncoder extends AbstractInet6AddressEncoder<String> {
             //Use this getByAddress function to prevent the InetAddress.getByAddress function from turning the value
             //into an Inet4Address automatically.
             return getByAddress(null, decodeHex(value.toCharArray()), -1);
-        } catch (UnknownHostException e) {
-            throw new TypeDecodingException(e);
-        } catch (DecoderException e) {
+        } catch (UnknownHostException | DecoderException e) {
             throw new TypeDecodingException(e);
         }
     }

--- a/mango-core/src/main/java/org/calrissian/mango/types/encoders/lexi/Inet6AddressReverseEncoder.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/encoders/lexi/Inet6AddressReverseEncoder.java
@@ -45,9 +45,7 @@ public class Inet6AddressReverseEncoder extends AbstractInet6AddressEncoder<Stri
             //Use this getByAddress function to prevent the InetAddress.getByAddress function from turning the value
             //into an Inet4Address automatically.
             return getByAddress(null, reverse(decodeHex(value.toCharArray())), -1);
-        } catch (UnknownHostException e) {
-            throw new TypeDecodingException(e);
-        } catch (DecoderException e) {
+        } catch (UnknownHostException | DecoderException e) {
             throw new TypeDecodingException(e);
         }
     }

--- a/mango-core/src/main/java/org/calrissian/mango/types/encoders/lexi/ReverseEncoder.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/encoders/lexi/ReverseEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,16 +18,12 @@ package org.calrissian.mango.types.encoders.lexi;
 
 import org.calrissian.mango.types.TypeEncoder;
 
-import java.nio.charset.Charset;
-
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static org.calrissian.mango.types.encoders.lexi.EncodingUtils.reverse;
 
 public class ReverseEncoder<T> implements TypeEncoder<T, String> {
     private static final long serialVersionUID = 1L;
-
-    //This is defined in Java 7 under StandardCharsets and should be replaced in the future.
-    private static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
 
     private final TypeEncoder<T, String> encoder;
 

--- a/mango-core/src/main/java/org/calrissian/mango/types/encoders/lexi/UnsignedIntegerEncoder.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/encoders/lexi/UnsignedIntegerEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.calrissian.mango.types.encoders.lexi;
 
 
 import com.google.common.primitives.UnsignedInteger;
-import org.calrissian.mango.types.encoders.AbstractIntegerEncoder;
 import org.calrissian.mango.types.encoders.AbstractUnsignedIntegerEncoder;
 
 import static com.google.common.base.Preconditions.checkArgument;

--- a/mango-core/src/main/java/org/calrissian/mango/uri/UriResolverRegistry.java
+++ b/mango-core/src/main/java/org/calrissian/mango/uri/UriResolverRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import java.util.Map;
 public class UriResolverRegistry {
 
     @SuppressWarnings("rawtypes")
-    private final Map<String, UriResolver> resolverMap = new LinkedHashMap<String, UriResolver>();
+    private final Map<String, UriResolver> resolverMap = new LinkedHashMap<>();
 
     @SuppressWarnings("rawtypes")
     public UriResolverRegistry addResolver(UriResolver resolver) {

--- a/mango-core/src/main/java/org/calrissian/mango/uri/resolver/BasicObjectUriResolver.java
+++ b/mango-core/src/main/java/org/calrissian/mango/uri/resolver/BasicObjectUriResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,8 +45,6 @@ public abstract class BasicObjectUriResolver<T> implements UriResolver<T> {
         oos.writeObject(obj);
         oos.flush();
 
-        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-
-        return bais;
+        return new ByteArrayInputStream(baos.toByteArray());
     }
 }

--- a/mango-core/src/main/java/org/calrissian/mango/uri/transform/ContextTransformService.java
+++ b/mango-core/src/main/java/org/calrissian/mango/uri/transform/ContextTransformService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,9 +27,9 @@ import java.util.Map;
 public class ContextTransformService {
 
     @SuppressWarnings("rawtypes")
-    private final Map<String, ContextTransformer> contextTransformMap = new HashMap<String, ContextTransformer>();
+    private final Map<String, ContextTransformer> contextTransformMap = new HashMap<>();
     @SuppressWarnings("rawtypes")
-    private final Map<Class, ContextTransformInterceptor> transformInterceptorMap = new HashMap<Class, ContextTransformInterceptor>();
+    private final Map<Class, ContextTransformInterceptor> transformInterceptorMap = new HashMap<>();
 
     @SuppressWarnings("rawtypes")
     public ContextTransformService(Collection<ContextTransformer> contextTransforms,

--- a/mango-core/src/test/java/org/calrissian/mango/batch/BatcherTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/batch/BatcherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public class BatcherTest {
     @Test
     public void sizeBatcherTest() throws InterruptedException {
 
-        TestListenter<Integer> listenter = new TestListenter<Integer>();
+        TestListenter<Integer> listenter = new TestListenter<>();
         final Batcher<Integer> batcher = BatcherBuilder.create()
                 .sizeBound(100)
                 .build(listenter);
@@ -72,7 +72,7 @@ public class BatcherTest {
     @Test
     public void sizeBatcherNonFullBatchTest() throws InterruptedException {
 
-        TestListenter<Integer> listenter = new TestListenter<Integer>();
+        TestListenter<Integer> listenter = new TestListenter<>();
         final Batcher<Integer> batcher = BatcherBuilder.create()
                 .sizeBound(100)
                 .build(listenter);
@@ -95,7 +95,7 @@ public class BatcherTest {
     @Test
     public void timeBatcherTest() throws InterruptedException {
 
-        TestListenter<Integer> listenter = new TestListenter<Integer>();
+        TestListenter<Integer> listenter = new TestListenter<>();
         final Batcher<Integer> batcher = BatcherBuilder.create()
                 .timeBound(10, MILLISECONDS)
                 .build(listenter);
@@ -119,7 +119,7 @@ public class BatcherTest {
     @Test
     public void sizeAndTimeBatcherTest() throws InterruptedException {
 
-        TestListenter<Integer> listenter = new TestListenter<Integer>();
+        TestListenter<Integer> listenter = new TestListenter<>();
         final Batcher<Integer> batcher = BatcherBuilder.create()
                 .sizeBound(100)
                 .timeBound(10, MILLISECONDS)
@@ -145,7 +145,7 @@ public class BatcherTest {
     //Tests to verify that ordering is maintained within batchers.
     @Test
     public void sequentialSizeBatcherTest() throws InterruptedException {
-        final List<Integer> results = new ArrayList<Integer>(1000);
+        final List<Integer> results = new ArrayList<>(1000);
         final Batcher<Integer> batcher = BatcherBuilder.create()
                 .sizeBound(100)
                 .listenerService(sameThreadExecutor()) //Required to guarantee ordering
@@ -169,7 +169,7 @@ public class BatcherTest {
 
     @Test
     public void sequentialTimeBatcherTest() throws InterruptedException {
-        final List<Integer> results = new ArrayList<Integer>(1000);
+        final List<Integer> results = new ArrayList<>(1000);
         final Batcher<Integer> batcher = BatcherBuilder.create()
                 .timeBound(10, MILLISECONDS)
                 .listenerService(sameThreadExecutor()) //Required to guarantee ordering
@@ -193,7 +193,7 @@ public class BatcherTest {
 
     @Test
     public void sequentialSizeOrTimeBatcherTest() throws InterruptedException {
-        final List<Integer> results = new ArrayList<Integer>(1000);
+        final List<Integer> results = new ArrayList<>(1000);
         final Batcher<Integer> batcher = BatcherBuilder.create()
                 .sizeBound(100)
                 .timeBound(10, MILLISECONDS)
@@ -220,7 +220,7 @@ public class BatcherTest {
     @Test(expected = IllegalStateException.class)
     public void noSizeOrTimeBound() {
         BatcherBuilder.create()
-                .build(new TestListenter<Object>());
+                .build(new TestListenter<>());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -361,7 +361,7 @@ public class BatcherTest {
 
                         latch.countDown();
                     } catch (InterruptedException e) {
-                        e.printStackTrace();
+                        throw new RuntimeException(e);
                     }
                 }
             });
@@ -373,7 +373,7 @@ public class BatcherTest {
 
         private AtomicInteger numBatches = new AtomicInteger(0);
         private AtomicInteger count = new AtomicInteger(0);
-        private ConcurrentLinkedQueue<Collection<T>> batches = new ConcurrentLinkedQueue<Collection<T>>();
+        private ConcurrentLinkedQueue<Collection<T>> batches = new ConcurrentLinkedQueue<>();
 
         @Override
         public void onBatch(Collection<T> batch) {

--- a/mango-core/src/test/java/org/calrissian/mango/collect/CloseableIterablesTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/collect/CloseableIterablesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ public class CloseableIterablesTest {
         try {
             wrapped.iterator();
             fail();
-        } catch (IllegalStateException ise) {
+        } catch (IllegalStateException ignored) {
         }
     }
 
@@ -75,7 +75,7 @@ public class CloseableIterablesTest {
         try {
             multTen.iterator();
             fail();
-        } catch (IllegalStateException ise) {
+        } catch (IllegalStateException ignored) {
         }
 
     }
@@ -94,7 +94,7 @@ public class CloseableIterablesTest {
         try {
             firstThree.iterator();
             fail();
-        } catch (IllegalStateException ise) {
+        } catch (IllegalStateException ignored) {
         }
     }
 
@@ -116,7 +116,7 @@ public class CloseableIterablesTest {
         try {
             odd.iterator();
             fail();
-        } catch (IllegalStateException ise) {
+        } catch (IllegalStateException ignored) {
         }
 
     }
@@ -135,7 +135,7 @@ public class CloseableIterablesTest {
         try {
             distinct.iterator();
             fail();
-        } catch (IllegalStateException ise) {
+        } catch (IllegalStateException ignored) {
         }
     }
 
@@ -161,13 +161,13 @@ public class CloseableIterablesTest {
         try {
             iterator.next();
             fail();
-        } catch (RuntimeException re) {
+        } catch (RuntimeException ignored) {
         }
         assertTrue(iterable.isClosed());
     }
 
     private MockIterable<Integer> testIterable() {
-        return new MockIterable<Integer>(asList(1, 2, 3, 4, 5));
+        return new MockIterable<>(asList(1, 2, 3, 4, 5));
     }
 
     private MockIterable<Integer> testExceptionThrowingIterable() {

--- a/mango-core/src/test/java/org/calrissian/mango/collect/CloseableIteratorsTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/collect/CloseableIteratorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,7 +98,7 @@ public class CloseableIteratorsTest {
         try {
             iterator.next();
             fail();
-        } catch (NoSuchElementException ne) {
+        } catch (NoSuchElementException ignored) {
         }
         iterator.close();
 
@@ -145,7 +145,7 @@ public class CloseableIteratorsTest {
         try {
             closeableIterator.next();
             fail();
-        } catch (RuntimeException re) {
+        } catch (RuntimeException ignored) {
         }
         assertTrue(iterator.isClosed());
 
@@ -154,7 +154,7 @@ public class CloseableIteratorsTest {
         closeableIterator.close();
         try {
             closeableIterator.next();
-        } catch (NoSuchElementException re) {
+        } catch (NoSuchElementException ignored) {
         }
         assertTrue(iterator.isClosed());
 
@@ -163,7 +163,7 @@ public class CloseableIteratorsTest {
         try {
             closeableIterator.remove();
             fail();
-        } catch (RuntimeException re) {
+        } catch (RuntimeException ignored) {
         }
         assertTrue(iterator.isClosed());
 
@@ -172,13 +172,13 @@ public class CloseableIteratorsTest {
         closeableIterator.close();
         try {
             closeableIterator.remove();
-        } catch (IllegalStateException re) {
+        } catch (IllegalStateException ignored) {
         }
         assertTrue(iterator.isClosed());
     }
 
     private MockIterator<Integer> testIterator() {
-        return new MockIterator<Integer>(asList(1, 2, 3, 4, 5).iterator());
+        return new MockIterator<>(asList(1, 2, 3, 4, 5).iterator());
     }
 
     private MockIterator<Integer> testExceptionThrowingIterator() {

--- a/mango-core/src/test/java/org/calrissian/mango/collect/FluentCloseableIterableTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/collect/FluentCloseableIterableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ public class FluentCloseableIterableTest {
         try {
             filter.iterator();
             fail();
-        } catch (IllegalStateException ise) {
+        } catch (IllegalStateException ignored) {
         }
     }
 

--- a/mango-core/src/test/java/org/calrissian/mango/criteria/domain/criteria/EqualsCriteriaTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/criteria/domain/criteria/EqualsCriteriaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 package org.calrissian.mango.criteria.domain.criteria;
 
 import org.calrissian.mango.criteria.support.ComparableComparator;
+import org.calrissian.mango.domain.Tuple;
 import org.calrissian.mango.domain.entity.BaseEntity;
 import org.calrissian.mango.domain.entity.Entity;
-import org.calrissian.mango.domain.Tuple;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;

--- a/mango-core/src/test/java/org/calrissian/mango/criteria/domain/criteria/HasKeyCriteriaTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/criteria/domain/criteria/HasKeyCriteriaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package org.calrissian.mango.criteria.domain.criteria;
 
+import org.calrissian.mango.domain.Tuple;
 import org.calrissian.mango.domain.entity.BaseEntity;
 import org.calrissian.mango.domain.entity.Entity;
-import org.calrissian.mango.domain.Tuple;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;

--- a/mango-core/src/test/java/org/calrissian/mango/criteria/domain/criteria/HasNotCriteriaTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/criteria/domain/criteria/HasNotCriteriaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package org.calrissian.mango.criteria.domain.criteria;
 
+import org.calrissian.mango.domain.Tuple;
 import org.calrissian.mango.domain.entity.BaseEntity;
 import org.calrissian.mango.domain.entity.Entity;
-import org.calrissian.mango.domain.Tuple;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;

--- a/mango-core/src/test/java/org/calrissian/mango/criteria/domain/criteria/LessThanCriteriaTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/criteria/domain/criteria/LessThanCriteriaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 package org.calrissian.mango.criteria.domain.criteria;
 
 import org.calrissian.mango.criteria.support.ComparableComparator;
+import org.calrissian.mango.domain.Tuple;
 import org.calrissian.mango.domain.entity.BaseEntity;
 import org.calrissian.mango.domain.entity.Entity;
-import org.calrissian.mango.domain.Tuple;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;

--- a/mango-core/src/test/java/org/calrissian/mango/criteria/domain/criteria/LessThanEqualsCriteriaTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/criteria/domain/criteria/LessThanEqualsCriteriaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 package org.calrissian.mango.criteria.domain.criteria;
 
 import org.calrissian.mango.criteria.support.ComparableComparator;
+import org.calrissian.mango.domain.Tuple;
 import org.calrissian.mango.domain.entity.BaseEntity;
 import org.calrissian.mango.domain.entity.Entity;
-import org.calrissian.mango.domain.Tuple;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;

--- a/mango-core/src/test/java/org/calrissian/mango/criteria/domain/criteria/NotEqualsCriteriaTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/criteria/domain/criteria/NotEqualsCriteriaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 package org.calrissian.mango.criteria.domain.criteria;
 
 import org.calrissian.mango.criteria.support.ComparableComparator;
+import org.calrissian.mango.domain.Tuple;
 import org.calrissian.mango.domain.entity.BaseEntity;
 import org.calrissian.mango.domain.entity.Entity;
-import org.calrissian.mango.domain.Tuple;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;

--- a/mango-core/src/test/java/org/calrissian/mango/criteria/domain/criteria/RangeCriteriaTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/criteria/domain/criteria/RangeCriteriaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 package org.calrissian.mango.criteria.domain.criteria;
 
 import org.calrissian.mango.criteria.support.ComparableComparator;
+import org.calrissian.mango.domain.Tuple;
 import org.calrissian.mango.domain.entity.BaseEntity;
 import org.calrissian.mango.domain.entity.Entity;
-import org.calrissian.mango.domain.Tuple;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;

--- a/mango-core/src/test/java/org/calrissian/mango/criteria/visitor/CollapseParentClauseVisitorTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/criteria/visitor/CollapseParentClauseVisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import org.calrissian.mango.criteria.builder.QueryBuilder;
 import org.calrissian.mango.criteria.domain.Node;
 import org.junit.Test;
 
-import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 
 /**

--- a/mango-core/src/test/java/org/calrissian/mango/hash/MerkleTreeTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/hash/MerkleTreeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.*;
 
 public class MerkleTreeTest {
@@ -41,9 +41,9 @@ public class MerkleTreeTest {
     public void testTreeBuilds() throws NoSuchAlgorithmException, IOException, ClassNotFoundException {
 
 
-        List<MockLeaf> leaves = Arrays.asList(new MockLeaf[]{leaf1, leaf2, leaf8, leaf7, leaf4});
+        List<MockLeaf> leaves = asList(leaf1, leaf2, leaf8, leaf7, leaf4);
 
-        MerkleTree<MockLeaf> tree = new MerkleTree<MockLeaf>(leaves, 2);
+        MerkleTree<MockLeaf> tree = new MerkleTree<>(leaves, 2);
 
         assertEquals("17a19db32d969668fb08f9a5491eb4fe", tree.getTopHash().getHash());
         assertEquals(2, tree.getTopHash().getChildren().size());
@@ -52,43 +52,43 @@ public class MerkleTreeTest {
     @Test
     public void testDiff_differentDimensionsFails() {
 
-        List<MockLeaf> leaves = Arrays.asList(new MockLeaf[]{leaf1, leaf2});
+        List<MockLeaf> leaves = asList(leaf1, leaf2);
 
-        MerkleTree<MockLeaf> tree = new MerkleTree<MockLeaf>(leaves, 2);
-        MerkleTree<MockLeaf> tree2 = new MerkleTree<MockLeaf>(leaves, 4);
+        MerkleTree<MockLeaf> tree = new MerkleTree<>(leaves, 2);
+        MerkleTree<MockLeaf> tree2 = new MerkleTree<>(leaves, 4);
 
         try {
             tree.diff(tree2);
             fail("Should have thrown exception");
-        } catch (IllegalStateException e) {
+        } catch (IllegalStateException ignored) {
         }
     }
 
     @Test
     public void testDiff_differentSizesFails() {
 
-        List<MockLeaf> leaves = Arrays.asList(new MockLeaf[]{leaf1, leaf2});
-        List<MockLeaf> leaves2 = Arrays.asList(new MockLeaf[]{leaf1, leaf2, leaf3});
+        List<MockLeaf> leaves = asList(leaf1, leaf2);
+        List<MockLeaf> leaves2 = asList(leaf1, leaf2, leaf3);
 
-        MerkleTree<MockLeaf> tree = new MerkleTree<MockLeaf>(leaves, 2);
-        MerkleTree<MockLeaf> tree2 = new MerkleTree<MockLeaf>(leaves2, 2);
+        MerkleTree<MockLeaf> tree = new MerkleTree<>(leaves, 2);
+        MerkleTree<MockLeaf> tree2 = new MerkleTree<>(leaves2, 2);
 
         try {
             tree.diff(tree2);
             fail("Should have thrown exception");
-        } catch (IllegalStateException e) {
+        } catch (IllegalStateException ignored) {
         }
     }
 
     @Test
     public void testEquals_false() {
 
-        List<MockLeaf> leaves = Arrays.asList(new MockLeaf[]{leaf1, leaf2});
-        List<MockLeaf> leaves2 = Arrays.asList(new MockLeaf[]{leaf1, leaf3});
+        List<MockLeaf> leaves = asList(leaf1, leaf2);
+        List<MockLeaf> leaves2 = asList(leaf1, leaf3);
 
 
-        MerkleTree<MockLeaf> tree = new MerkleTree<MockLeaf>(leaves, 2);
-        MerkleTree<MockLeaf> tree2 = new MerkleTree<MockLeaf>(leaves2, 2);
+        MerkleTree<MockLeaf> tree = new MerkleTree<>(leaves, 2);
+        MerkleTree<MockLeaf> tree2 = new MerkleTree<>(leaves2, 2);
 
         assertFalse(tree.equals(tree2));
         assertFalse(tree2.equals(tree));
@@ -97,11 +97,11 @@ public class MerkleTreeTest {
     @Test
     public void testEquals_true() {
 
-        List<MockLeaf> leaves = Arrays.asList(new MockLeaf[]{leaf1, leaf2});
-        List<MockLeaf> leaves2 = Arrays.asList(new MockLeaf[]{leaf1, leaf2});
+        List<MockLeaf> leaves = asList(leaf1, leaf2);
+        List<MockLeaf> leaves2 = asList(leaf1, leaf2);
 
-        MerkleTree<MockLeaf> tree = new MerkleTree<MockLeaf>(leaves, 2);
-        MerkleTree<MockLeaf> tree2 = new MerkleTree<MockLeaf>(leaves2, 2);
+        MerkleTree<MockLeaf> tree = new MerkleTree<>(leaves, 2);
+        MerkleTree<MockLeaf> tree2 = new MerkleTree<>(leaves2, 2);
 
         assertTrue(tree.equals(tree2));
         assertTrue(tree2.equals(tree));
@@ -110,11 +110,11 @@ public class MerkleTreeTest {
     @Test
     public void testDiff() {
 
-        List<MockLeaf> leaves = Arrays.asList(new MockLeaf[]{leaf1, leaf2});
-        List<MockLeaf> leaves2 = Arrays.asList(new MockLeaf[]{leaf1, leaf3});
+        List<MockLeaf> leaves = asList(leaf1, leaf2);
+        List<MockLeaf> leaves2 = asList(leaf1, leaf3);
 
-        MerkleTree<MockLeaf> tree = new MerkleTree<MockLeaf>(leaves, 2);
-        MerkleTree<MockLeaf> tree2 = new MerkleTree<MockLeaf>(leaves2, 2);
+        MerkleTree<MockLeaf> tree = new MerkleTree<>(leaves, 2);
+        MerkleTree<MockLeaf> tree2 = new MerkleTree<>(leaves2, 2);
 
         List<MockLeaf> diffs = tree.diff(tree2);
 

--- a/mango-core/src/test/java/org/calrissian/mango/types/canonicalizer/CanonicalizerContextTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/types/canonicalizer/CanonicalizerContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,7 @@ package org.calrissian.mango.types.canonicalizer;
 import org.calrissian.mango.domain.ip.IPv4;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class CanonicalizerContextTest {
 

--- a/mango-core/src/test/java/org/calrissian/mango/uri/service/ContextTransformServiceTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/uri/service/ContextTransformServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,8 +41,8 @@ public class ContextTransformServiceTest {
     @Before
     public void setUp() {
 
-        Collection<ContextTransformer> transformers = new ArrayList<ContextTransformer>();
-        Collection<ContextTransformInterceptor> interceptors = new ArrayList<ContextTransformInterceptor>();
+        Collection<ContextTransformer> transformers = new ArrayList<>();
+        Collection<ContextTransformInterceptor> interceptors = new ArrayList<>();
 
         transformers.add(new MockContextTransformer());
         interceptors.add(new MockContextTransformInterceptor());
@@ -81,10 +81,8 @@ public class ContextTransformServiceTest {
                 while ((n = reader.read(buffer)) != -1) {
                     writer.write(buffer, 0, n);
                 }
-            } catch (UnsupportedEncodingException e) {
-                e.printStackTrace();  //To change body of catch statement use File | Settings | File Templates.
             } catch (IOException e) {
-                e.printStackTrace();  //To change body of catch statement use File | Settings | File Templates.
+                throw new RuntimeException(e);
             } finally {
                 is.close();
             }

--- a/mango-jms/src/main/java/org/calrissian/mango/jms/stream/AbstractJmsFileTransferSupport.java
+++ b/mango-jms/src/main/java/org/calrissian/mango/jms/stream/AbstractJmsFileTransferSupport.java
@@ -144,7 +144,7 @@ public abstract class AbstractJmsFileTransferSupport {
     public void sendStream(Request req, final Destination replyTo)
             throws IOException {
 
-        DigestInputStream is = null;
+        DigestInputStream is;
         Assert.notNull(req, "Request cannot be null");
         final URI downloadUrl;
         try {
@@ -312,11 +312,10 @@ public abstract class AbstractJmsFileTransferSupport {
         } catch (Exception e) {
             throw new JmsFileTransferException(e);
         } finally {
-            if (is != null)
-                try {
-                    is.close();
-                } catch (IOException e) {
-                }
+            try {
+                is.close();
+            } catch (IOException ignored) {
+            }
             if (queueListener != null)
                 queueListener.close();
         }

--- a/mango-jms/src/main/java/org/calrissian/mango/jms/stream/JmsFileReceiverInputStream.java
+++ b/mango-jms/src/main/java/org/calrissian/mango/jms/stream/JmsFileReceiverInputStream.java
@@ -113,9 +113,7 @@ public class JmsFileReceiverInputStream extends AbstractBufferedInputStream {
 
             return data; //null is fine, as abstract will simply retry until done is set.
 
-        } catch (JMSException e) {
-            throw new JmsFileTransferException(e);
-        } catch (NoSuchAlgorithmException e) {
+        } catch (JMSException | NoSuchAlgorithmException e) {
             throw new JmsFileTransferException(e);
         }
     }

--- a/mango-jms/src/main/java/org/calrissian/mango/jms/stream/JmsFileSenderListener.java
+++ b/mango-jms/src/main/java/org/calrissian/mango/jms/stream/JmsFileSenderListener.java
@@ -40,13 +40,13 @@ public class JmsFileSenderListener extends AbstractJmsFileTransferSupport
 
     @Override
     public void onMessage(Message request) {
-        Request req = null;
+        Request req;
         try {
             req = fromRequestMessage(request);
             taskExecutor.execute(new JmsFileSenderRunnable(req, request
                     .getJMSReplyTo()));
         } catch (Exception e1) {
-            e1.printStackTrace();
+            throw new RuntimeException(e1);
         }
 
     }
@@ -66,7 +66,7 @@ public class JmsFileSenderListener extends AbstractJmsFileTransferSupport
             try {
                 sendStream(req, jmsReplyTo);
             } catch (Exception e) {
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
         }
 

--- a/mango-jms/src/main/java/org/calrissian/mango/jms/stream/utils/MessageQueueListener.java
+++ b/mango-jms/src/main/java/org/calrissian/mango/jms/stream/utils/MessageQueueListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 The Calrissian Authors
+ * Copyright (C) 2014 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 @Deprecated
 public class MessageQueueListener implements MessageListener {
 
-    private BlockingQueue<Message> queueMessages = new LinkedBlockingQueue<Message>();
+    private BlockingQueue<Message> queueMessages = new LinkedBlockingQueue<>();
     private SimpleMessageListenerContainer messageListenerContainer;
     private AbstractJmsFileTransferSupport support;
 

--- a/mango-jms/src/main/java/org/calrissian/mango/jms/stream/utils/SendReceiveRequestor.java
+++ b/mango-jms/src/main/java/org/calrissian/mango/jms/stream/utils/SendReceiveRequestor.java
@@ -56,7 +56,7 @@ public class SendReceiveRequestor implements MessagePostProcessor {
 
     protected String createReceiveSelector() {
         String s = (send) ? replyToId : recvId;
-        return new StringBuilder().append(RECV_ID).append(" = '").append(s).append("'").toString();
+        return RECV_ID + " = '" + s + "'";
     }
 
     protected Message populateProperties(Message msg) throws JMSException {

--- a/mango-jms/src/main/java/org/calrissian/mango/jms/uri/JmsUriSender.java
+++ b/mango-jms/src/main/java/org/calrissian/mango/jms/uri/JmsUriSender.java
@@ -45,7 +45,7 @@ public class JmsUriSender extends JmsFileSenderListener
     @Override
     public void onMessage(Message request) {
 
-        Request req = null;
+        Request req;
         try {
             req = DomainMessageUtils.fromRequestMessage(request);
             URI uri = new URI(req.getDownloadUri());
@@ -69,7 +69,7 @@ public class JmsUriSender extends JmsFileSenderListener
             }
 
         } catch (Exception e1) {
-            e1.printStackTrace();
+            throw new RuntimeException(e1);
         }
 
     }
@@ -89,7 +89,7 @@ public class JmsUriSender extends JmsFileSenderListener
             try {
                 sendStream(req, jmsReplyTo);
             } catch (Exception e) {
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
         }
 

--- a/mango-jms/src/test/java/org/calrissian/mango/jms/stream/JmsFileTransferSupportTest.java
+++ b/mango-jms/src/test/java/org/calrissian/mango/jms/stream/JmsFileTransferSupportTest.java
@@ -75,7 +75,7 @@ public class JmsFileTransferSupportTest extends TestCase {
                     return null;
                 }
             });
-        } catch (Error e) {
+        } catch (Error ignored) {
         }
 
         final ActiveMQTopic ft = new ActiveMQTopic("testFileTransfer");
@@ -111,8 +111,8 @@ public class JmsFileTransferSupportTest extends TestCase {
         receiver.setPieceSize(9);
 
         JmsFileReceiverInputStream stream = (JmsFileReceiverInputStream) receiver.receiveStream("testprot:test");
-        StringBuffer buffer = new StringBuffer();
-        int read = 0;
+        StringBuilder buffer = new StringBuilder();
+        int read;
         while ((read = stream.read()) >= 0) {
             buffer.append((char) read);
         }

--- a/mango-json/src/main/java/org/calrissian/mango/json/deser/BaseTupleStoreDeserializer.java
+++ b/mango-json/src/main/java/org/calrissian/mango/json/deser/BaseTupleStoreDeserializer.java
@@ -16,7 +16,6 @@
 package org.calrissian.mango.json.deser;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -35,7 +34,7 @@ public abstract class BaseTupleStoreDeserializer<T extends TupleStore> extends J
 
     private static final TypeReference TR = new TypeReference<Map<String, Collection<Tuple>>>(){};
     @Override
-    public T deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+    public T deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
         JsonNode root = jsonParser.getCodec().readTree(jsonParser);
         T tupleStore = deserialize(root);
 

--- a/mango-json/src/main/java/org/calrissian/mango/json/deser/EntityDeserializer.java
+++ b/mango-json/src/main/java/org/calrissian/mango/json/deser/EntityDeserializer.java
@@ -26,7 +26,6 @@ public class EntityDeserializer extends BaseTupleStoreDeserializer<BaseEntity> {
         String type = root.get("type").asText();
         String id = root.get("id").asText();
 
-        BaseEntity toReturn =  new BaseEntity(type, id);
-        return toReturn;
+        return new BaseEntity(type, id);
     }
 }

--- a/mango-json/src/main/java/org/calrissian/mango/json/deser/EventDeserializer.java
+++ b/mango-json/src/main/java/org/calrissian/mango/json/deser/EventDeserializer.java
@@ -26,8 +26,7 @@ public class EventDeserializer extends BaseTupleStoreDeserializer<BaseEvent> {
         String id = root.get("id").asText();
         long timestamp = root.get("timestamp").asLong();
 
-        BaseEvent toReturn =  new BaseEvent(id, timestamp);
-        return toReturn;
+        return new BaseEvent(id, timestamp);
     }
 
 }

--- a/mango-json/src/main/java/org/calrissian/mango/json/deser/NodeDeserializer.java
+++ b/mango-json/src/main/java/org/calrissian/mango/json/deser/NodeDeserializer.java
@@ -50,64 +50,69 @@ public class NodeDeserializer extends JsonDeserializer<Node> {
     }
 
     protected Node parseField(String fieldKey, JsonNode fieldJson) throws IOException {
-        if ("and".equals(fieldKey)) {
-            AndNode andNode = new AndNode();
-            JsonNode children = fieldJson.get("children");
-            if (children instanceof ArrayNode) {
-                ArrayNode childrenArray = (ArrayNode) children;
-                Iterator<JsonNode> elements = childrenArray.elements();
-                while (elements.hasNext()) {
-                    JsonNode entry = elements.next();
-                    Iterator<String> fieldNames = entry.fieldNames();
-                    while (fieldNames.hasNext()) {
-                        String key = fieldNames.next();
-                        andNode.addChild(parseField(key, entry.get(key)));
+        switch (fieldKey) {
+            case "and": {
+                AndNode andNode = new AndNode();
+                JsonNode children = fieldJson.get("children");
+                if (children instanceof ArrayNode) {
+                    ArrayNode childrenArray = (ArrayNode) children;
+                    Iterator<JsonNode> elements = childrenArray.elements();
+                    while (elements.hasNext()) {
+                        JsonNode entry = elements.next();
+                        Iterator<String> fieldNames = entry.fieldNames();
+                        while (fieldNames.hasNext()) {
+                            String key = fieldNames.next();
+                            andNode.addChild(parseField(key, entry.get(key)));
+                        }
                     }
                 }
+                return andNode;
             }
-            return andNode;
-        } else if ("or".equals(fieldKey)) {
-            OrNode orNode = new OrNode();
-            JsonNode children = fieldJson.get("children");
-            if (children instanceof ArrayNode) {
-                ArrayNode childrenArray = (ArrayNode) children;
-                Iterator<JsonNode> elements = childrenArray.elements();
-                while (elements.hasNext()) {
-                    JsonNode entry = elements.next();
-                    Iterator<String> fieldNames = entry.fieldNames();
-                    while (fieldNames.hasNext()) {
-                        String key = fieldNames.next();
-                        orNode.addChild(parseField(key, entry.get(key)));
+            case "or": {
+                OrNode orNode = new OrNode();
+                JsonNode children = fieldJson.get("children");
+                if (children instanceof ArrayNode) {
+                    ArrayNode childrenArray = (ArrayNode) children;
+                    Iterator<JsonNode> elements = childrenArray.elements();
+                    while (elements.hasNext()) {
+                        JsonNode entry = elements.next();
+                        Iterator<String> fieldNames = entry.fieldNames();
+                        while (fieldNames.hasNext()) {
+                            String key = fieldNames.next();
+                            orNode.addChild(parseField(key, entry.get(key)));
+                        }
                     }
                 }
+                return orNode;
             }
-            return orNode;
-        } else if ("eq".equals(fieldKey)) {
-            String key = fieldJson.get("key").asText();
-            String type = fieldJson.get("type").asText();
-            String val_str = fieldJson.get("value").asText();
+            case "eq": {
+                String key = fieldJson.get("key").asText();
+                String type = fieldJson.get("type").asText();
+                String val_str = fieldJson.get("value").asText();
 
-            Object obj = this.typeRegistry.decode(type, val_str);
-            return new EqualsLeaf(key, obj, null);
-        } else if ("neq".equals(fieldKey)) {
-            String key = fieldJson.get("key").asText();
-            String type = fieldJson.get("type").asText();
-            String val_str = fieldJson.get("value").asText();
+                Object obj = this.typeRegistry.decode(type, val_str);
+                return new EqualsLeaf(key, obj, null);
+            }
+            case "neq": {
+                String key = fieldJson.get("key").asText();
+                String type = fieldJson.get("type").asText();
+                String val_str = fieldJson.get("value").asText();
 
-            Object obj = this.typeRegistry.decode(type, val_str);
-            return new NotEqualsLeaf(key, obj, null);
-        } else if ("range".equals(fieldKey)) {
-            String key = fieldJson.get("key").asText();
-            String type = fieldJson.get("type").asText();
-            String start_str = fieldJson.get("start").asText();
-            String end_str = fieldJson.get("end").asText();
+                Object obj = this.typeRegistry.decode(type, val_str);
+                return new NotEqualsLeaf(key, obj, null);
+            }
+            case "range": {
+                String key = fieldJson.get("key").asText();
+                String type = fieldJson.get("type").asText();
+                String start_str = fieldJson.get("start").asText();
+                String end_str = fieldJson.get("end").asText();
 
-            Object start = this.typeRegistry.decode(type, start_str);
-            Object end = this.typeRegistry.decode(type, end_str);
-            return new RangeLeaf(key, start, end, null);
-        } else {
-            throw new IllegalArgumentException("Unsupported field: " + fieldKey);
+                Object start = this.typeRegistry.decode(type, start_str);
+                Object end = this.typeRegistry.decode(type, end_str);
+                return new RangeLeaf(key, start, end, null);
+            }
+            default:
+                throw new IllegalArgumentException("Unsupported field: " + fieldKey);
         }
-
     }
 }

--- a/mango-json/src/main/java/org/calrissian/mango/json/deser/TupleDeserializer.java
+++ b/mango-json/src/main/java/org/calrissian/mango/json/deser/TupleDeserializer.java
@@ -48,7 +48,7 @@ public class TupleDeserializer extends JsonDeserializer<Tuple> {
             value = typeRegistry.decode(type, val_str);
         }
 
-        Map<String, Object> metadata = new HashMap<String, Object>();
+        Map<String, Object> metadata = new HashMap<>();
         JsonNode metadataArray = root.get("metadata");
         if(metadataArray != null) {
             for (JsonNode metadataItem : metadataArray) {

--- a/mango-json/src/main/java/org/calrissian/mango/json/ser/BaseTupleStoreSerializer.java
+++ b/mango-json/src/main/java/org/calrissian/mango/json/ser/BaseTupleStoreSerializer.java
@@ -17,7 +17,6 @@ package org.calrissian.mango.json.ser;
 
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import org.calrissian.mango.domain.TupleStore;
@@ -28,7 +27,7 @@ public abstract class BaseTupleStoreSerializer<T extends TupleStore> extends Jso
 
 
     @Override
-    public void serialize(T t, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
+    public void serialize(T t, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
 
         jsonGenerator.writeStartObject();
 

--- a/mango-json/src/main/java/org/calrissian/mango/json/util/json/ArrayJsonNode.java
+++ b/mango-json/src/main/java/org/calrissian/mango/json/util/json/ArrayJsonNode.java
@@ -34,7 +34,7 @@ import static org.calrissian.mango.json.util.json.JsonUtil.objectToNode;
 class ArrayJsonNode implements JsonTreeNode {
 
     private final ObjectMapper objectMapper;
-    private final List<JsonTreeNode> children = new ArrayList<JsonTreeNode>();
+    private final List<JsonTreeNode> children = new ArrayList<>();
 
     public ArrayJsonNode(ObjectMapper objectMapper) {
         checkNotNull(objectMapper);
@@ -52,7 +52,7 @@ class ArrayJsonNode implements JsonTreeNode {
 
             try {
                 child = children.get(levelToIdx.get(level));
-            }catch(Exception e) {}
+            }catch(Exception ignored) {}
 
             // look toJson see if next item exists, otherwise, create it, add it toJson children, and visit it.
             String nextKey = keys[level + 1];

--- a/mango-json/src/main/java/org/calrissian/mango/json/util/json/JsonMetadata.java
+++ b/mango-json/src/main/java/org/calrissian/mango/json/util/json/JsonMetadata.java
@@ -44,7 +44,7 @@ class JsonMetadata {
      * @param level
      * @param index
      */
-    static final void setArrayIndex(Map<String,Object> meta, int level, int index) {
+    static void setArrayIndex(Map<String,Object> meta, int level, int index) {
         meta.put(level + ARRAY_IDX_SUFFIX, index);
     }
 
@@ -53,7 +53,7 @@ class JsonMetadata {
      * arbitrarily nested set of json.
      * @param meta
      */
-    static final void setFlattenedJsonProp(Map<String,Object> meta) {
+    static void setFlattenedJsonProp(Map<String,Object> meta) {
         meta.put(JSON_PROP, true);
     }
 
@@ -62,7 +62,7 @@ class JsonMetadata {
      * arbitrarily nested set of json.
      * @param meta
      */
-    static final boolean isFlattenedJson(Map<String,Object> meta) {
+    static boolean isFlattenedJson(Map<String,Object> meta) {
         return meta.containsKey(JSON_PROP) && meta.get(JSON_PROP).equals(true);
     }
 
@@ -73,7 +73,7 @@ class JsonMetadata {
      * @param level
      * @return
      */
-    static final Integer getArrayIndex(Map<String,Object> meta, int level) {
+    static Integer getArrayIndex(Map<String,Object> meta, int level) {
         return (Integer)meta.get(level + ARRAY_IDX_SUFFIX);
     }
 
@@ -84,7 +84,7 @@ class JsonMetadata {
      * @param level
      * @return
      */
-    static final boolean hasArrayIndex(Map<String,Object> meta, int level) {
+    static boolean hasArrayIndex(Map<String,Object> meta, int level) {
         return meta.containsKey(level + ARRAY_IDX_SUFFIX);
     }
 
@@ -96,9 +96,9 @@ class JsonMetadata {
      * @param meta
      * @return
      */
-    static final Map<Integer, Integer> levelsToIndices(Map<String,Object> meta) {
+    static Map<Integer, Integer> levelsToIndices(Map<String,Object> meta) {
         Set<Map.Entry<String, Object>> entries = meta.entrySet();
-        Map<Integer, Integer> levelToIdx = new HashMap<Integer, Integer>();
+        Map<Integer, Integer> levelToIdx = new HashMap<>();
         for(Map.Entry<String,Object> entry : entries)
             if(entry.getKey().endsWith(ARRAY_IDX_SUFFIX))
                 levelToIdx.put(parseInt(Splitter.on('.').splitToList(entry.getKey()).get(0)), (Integer)entry.getValue());

--- a/mango-json/src/main/java/org/calrissian/mango/json/util/json/JsonTupleStore.java
+++ b/mango-json/src/main/java/org/calrissian/mango/json/util/json/JsonTupleStore.java
@@ -49,7 +49,7 @@ import static org.calrissian.mango.json.util.json.JsonUtil.nodeToObject;
 public class JsonTupleStore {
 
     private static final String JSON_DELIM = "$";
-    private static final Pair<Integer,Integer> DEFAULT_PAIR = new Pair<Integer, Integer>(-1, -1);
+    private static final Pair<Integer,Integer> DEFAULT_PAIR = new Pair<>(-1, -1);
     private static final Splitter SPLITTER = Splitter.on(JSON_DELIM);
 
     private JsonTupleStore() {}
@@ -62,8 +62,8 @@ public class JsonTupleStore {
      * @return
      * @throws IOException
      */
-    public static final Collection<Tuple> fromJson(ObjectNode object) throws IOException {
-        Collection<Tuple> tuples = new HashSet<Tuple>();
+    public static Collection<Tuple> fromJson(ObjectNode object) throws IOException {
+        Collection<Tuple> tuples = new HashSet<>();
         convertJsonObject(tuples, object, "", 0, new HashMap<String, Object>());
 
         return tuples;
@@ -79,7 +79,7 @@ public class JsonTupleStore {
      * @return
      * @throws IOException
      */
-    public static final Collection<Tuple> fromJson(String json, ObjectMapper objectMapper) throws IOException {
+    public static Collection<Tuple> fromJson(String json, ObjectMapper objectMapper) throws IOException {
         checkNotNull(json);
         JsonNode object = objectMapper.readTree(json);
         if(object.isObject())
@@ -96,7 +96,7 @@ public class JsonTupleStore {
      * @param objectMapper
      * @return
      */
-    public static final String toJsonString(Collection<Tuple> tupleCollection, ObjectMapper objectMapper) {
+    public static String toJsonString(Collection<Tuple> tupleCollection, ObjectMapper objectMapper) {
         return toJson(tupleCollection, objectMapper).toString();
     }
 
@@ -108,12 +108,12 @@ public class JsonTupleStore {
      * @param tupleCollection
      * @return
      */
-    public static final ObjectNode toJson(Collection<Tuple> tupleCollection, ObjectMapper objectMapper) {
+    public static ObjectNode toJson(Collection<Tuple> tupleCollection, ObjectMapper objectMapper) {
 
         checkNotNull(tupleCollection);
         checkNotNull(objectMapper);
 
-        List<Tuple> tuples = new ArrayList<Tuple>(tupleCollection);
+        List<Tuple> tuples = new ArrayList<>(tupleCollection);
 
         sort(tuples, new FlattenedLevelsComparator());
 
@@ -154,7 +154,7 @@ public class JsonTupleStore {
      */
     public static class FlattenedLevelsComparator implements Comparator<Tuple> {
 
-        private Map<Tuple, Integer> levelsCache = new HashMap<Tuple, Integer>();
+        private Map<Tuple, Integer> levelsCache = new HashMap<>();
 
         /**
          * Calculating the occurrence of a string within another can be costly so .'s and ['s will be
@@ -185,10 +185,10 @@ public class JsonTupleStore {
             for(int i = 0; i < Math.max(levels1, levels2); i++) {
 
                 Pair<Integer, Integer> pair1 = hasArrayIndex(tuple.getMetadata(), i)?
-                        new Pair<Integer, Integer>(i, getArrayIndex(tuple.getMetadata(), i)) : DEFAULT_PAIR;
+                        new Pair<>(i, getArrayIndex(tuple.getMetadata(), i)) : DEFAULT_PAIR;
 
                 Pair<Integer, Integer> pair2 = hasArrayIndex(tuple2.getMetadata(), i) ?
-                        new Pair<Integer, Integer>(i, getArrayIndex(tuple2.getMetadata(), i)) : DEFAULT_PAIR;
+                        new Pair<>(i, getArrayIndex(tuple2.getMetadata(), i)) : DEFAULT_PAIR;
 
                 comparisonChain = comparisonChain.compare(pair1.getOne(), pair2.getOne());
                 comparisonChain = comparisonChain.compare(pair1.getTwo(), pair2.getTwo());
@@ -201,9 +201,9 @@ public class JsonTupleStore {
 
             return comparisonChain.result();
         }
-    };
+    }
 
-    private static final void convertJsonObject(Collection<Tuple> tuples, JsonNode object,  String intialKey, int nestedLevel, Map<String, Object> metadata) {
+    private static void convertJsonObject(Collection<Tuple> tuples, JsonNode object,  String intialKey, int nestedLevel, Map<String, Object> metadata) {
 
         Iterator<Map.Entry<String,JsonNode>> fields = object.fields();
         while(fields.hasNext()) {
@@ -226,11 +226,9 @@ public class JsonTupleStore {
         }
     }
 
+    private static void convertJsonArray(Collection<Tuple> tuples, JsonNode jsonArray, String intialKey, int nestedLevel, Map<String, Object> metadata) {
 
-
-    private static final void convertJsonArray(Collection<Tuple> tuples, JsonNode jsonArray, String intialKey, int nestedLevel, Map<String, Object> metadata) {
-
-        Map<String,Object> map = new HashMap<String, Object>(metadata);
+        Map<String,Object> map = new HashMap<>(metadata);
         for(int i = 0; i < jsonArray.size(); i++) {
 
             JsonNode obj = jsonArray.get(i);

--- a/mango-json/src/main/java/org/calrissian/mango/json/util/json/JsonUtil.java
+++ b/mango-json/src/main/java/org/calrissian/mango/json/util/json/JsonUtil.java
@@ -22,7 +22,7 @@ public class JsonUtil {
 
     private JsonUtil() {}
 
-    public static final JsonNode objectToNode(Object obj) {
+    static JsonNode objectToNode(Object obj) {
 
         if(obj instanceof Boolean)
             return BooleanNode.valueOf((Boolean) obj);
@@ -30,14 +30,16 @@ public class JsonUtil {
             return new IntNode((Integer)obj);
         else if(obj instanceof Long)
             return new LongNode((Long)obj);
-        else if(obj instanceof Double || obj instanceof Float)
+        else if(obj instanceof Double)
             return new DoubleNode((Double)obj);
+        else if (obj instanceof Float)
+            return new DoubleNode(((Float) obj).doubleValue());
         else if(obj instanceof String)
             return new TextNode((String)obj);
         else return null;
     }
 
-    public static Object nodeToObject(JsonNode jsonNode) {
+    static Object nodeToObject(JsonNode jsonNode) {
         if(jsonNode.isBoolean())
             return jsonNode.asBoolean();
         else if(jsonNode.isDouble())

--- a/mango-json/src/main/java/org/calrissian/mango/json/util/json/ObjectJsonNode.java
+++ b/mango-json/src/main/java/org/calrissian/mango/json/util/json/ObjectJsonNode.java
@@ -17,7 +17,7 @@ package org.calrissian.mango.json.util.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.*;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,7 +32,7 @@ import static org.calrissian.mango.json.util.json.JsonUtil.objectToNode;
 class ObjectJsonNode implements JsonTreeNode {
 
     private final ObjectMapper objectMapper;
-    private final Map<String, JsonTreeNode> children = new HashMap<String, JsonTreeNode>();
+    private final Map<String, JsonTreeNode> children = new HashMap<>();
 
     public ObjectJsonNode(ObjectMapper objectMapper) {
         checkNotNull(objectMapper);

--- a/mango-json/src/test/java/org/calrissian/mango/json/deser/EntityDeserializerTest.java
+++ b/mango-json/src/test/java/org/calrissian/mango/json/deser/EntityDeserializerTest.java
@@ -45,7 +45,7 @@ public class EntityDeserializerTest {
 
         assertEquals(actualEntity.getType(), entity.getType());
         assertEquals(actualEntity.getId(), entity.getId());
-        assertEquals(new HashSet<Tuple>(actualEntity.getTuples()), new HashSet<Tuple>(entity.getTuples()));
+        assertEquals(new HashSet<>(actualEntity.getTuples()), new HashSet<>(entity.getTuples()));
     }
 
 

--- a/mango-json/src/test/java/org/calrissian/mango/json/deser/EventDeserializerTest.java
+++ b/mango-json/src/test/java/org/calrissian/mango/json/deser/EventDeserializerTest.java
@@ -18,8 +18,6 @@ package org.calrissian.mango.json.deser;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.calrissian.mango.domain.Tuple;
-import org.calrissian.mango.domain.entity.BaseEntity;
-import org.calrissian.mango.domain.entity.Entity;
 import org.calrissian.mango.domain.event.BaseEvent;
 import org.calrissian.mango.domain.event.Event;
 import org.calrissian.mango.json.MangoModule;
@@ -47,7 +45,7 @@ public class EventDeserializerTest {
 
         assertEquals(actualEntity.getId(), event.getId());
         assertEquals(actualEntity.getTimestamp(), event.getTimestamp());
-        assertEquals(new HashSet<Tuple>(actualEntity.getTuples()), new HashSet<Tuple>(event.getTuples()));
+        assertEquals(new HashSet<>(actualEntity.getTuples()), new HashSet<>(event.getTuples()));
     }
 
 

--- a/mango-json/src/test/java/org/calrissian/mango/json/uri/transform/JsonContextTransformTest.java
+++ b/mango-json/src/test/java/org/calrissian/mango/json/uri/transform/JsonContextTransformTest.java
@@ -37,7 +37,7 @@ public class JsonContextTransformTest {
     @Before
     public void setUp() {
 
-        Collection<ContextTransformer> transformers = new ArrayList<ContextTransformer>();
+        Collection<ContextTransformer> transformers = new ArrayList<>();
         transformers.add(new JsonContextTransform(new ObjectMapper()));
 
         contextTransformService = new ContextTransformService(transformers, null);
@@ -47,7 +47,7 @@ public class JsonContextTransformTest {
     @Test
     public void testJsonContextTransform() throws Exception {
 
-        ArrayList<String> items = new ArrayList<String>();
+        ArrayList<String> items = new ArrayList<>();
         items.add("item1");
         items.add("item2");
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@ limitations under the License.
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.1</version>
           <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
+            <source>1.7</source>
+            <target>1.7</target>
             <optimize>true</optimize>
           </configuration>
         </plugin>


### PR DESCRIPTION
Fixes #53.  Syntax conversion to Java7.  Used diamond brackets, collapsed exceptions and use of string switch statements.  Also cleaned up language level warnings.