### PR TITLE
EventIdentifier type encoders

### DIFF
--- a/mango-core/src/main/java/org/calrissian/mango/types/LexiTypeEncoders.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/LexiTypeEncoders.java
@@ -19,6 +19,7 @@ package org.calrissian.mango.types;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.calrissian.mango.domain.entity.EntityIdentifier;
+import org.calrissian.mango.domain.event.EventIdentifier;
 import org.calrissian.mango.domain.ip.IPv4;
 import org.calrissian.mango.domain.ip.IPv6;
 import org.calrissian.mango.types.encoders.lexi.*;
@@ -58,13 +59,13 @@ public class LexiTypeEncoders {
      * Contains the full set of supported type encoders
      */
     public static final TypeRegistry<String> LEXI_TYPES = new TypeRegistry<>(LEXI_JAVA_TYPES,
-            ipv4Encoder(), ipv6Encoder(), entityIdentifierEncoder(),
+            ipv4Encoder(), ipv6Encoder(), entityIdentifierEncoder(), eventIdentifierEncoder(),
             unsignedIntegerEncoder(), unsignedLongEncoder()
     );
 
     public static final TypeRegistry<String> LEXI_REV_TYPES = new TypeRegistry<>(LEXI_REV_JAVA_TYPES,
-            ipv4RevEncoder(), ipv6RevEncoder(),
-            unsignedIntegerRevEncoder(), unsignedLongRevEncoder(), entityIdentifierRevEncoder()
+            ipv4RevEncoder(), ipv6RevEncoder(), entityIdentifierRevEncoder(), eventIdentifierRevEncoder(),
+            unsignedIntegerRevEncoder(), unsignedLongRevEncoder()
     );
 
     private static <T> TypeEncoder<T, String> reverseEncoder(TypeEncoder<T, String> sourceEncoder) {
@@ -195,11 +196,17 @@ public class LexiTypeEncoders {
         return SimpleTypeEncoders.entityIdentifierEncoder();
     }
 
-
     public static TypeEncoder<EntityIdentifier, String> entityIdentifierRevEncoder() {
         return reverseEncoder(SimpleTypeEncoders.entityIdentifierEncoder());
     }
 
+    public static TypeEncoder<EventIdentifier, String> eventIdentifierEncoder() {
+        return new EventIdentifierEncoder();
+    }
+
+    public static TypeEncoder<EventIdentifier, String> eventIdentifierRevEncoder() {
+        return reverseEncoder(eventIdentifierEncoder());
+    }
 
     public static TypeEncoder<UnsignedInteger, String> unsignedIntegerEncoder() {
         return new UnsignedIntegerEncoder();

--- a/mango-core/src/main/java/org/calrissian/mango/types/SimpleTypeEncoders.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/SimpleTypeEncoders.java
@@ -19,6 +19,7 @@ package org.calrissian.mango.types;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.calrissian.mango.domain.entity.EntityIdentifier;
+import org.calrissian.mango.domain.event.EventIdentifier;
 import org.calrissian.mango.domain.ip.IPv4;
 import org.calrissian.mango.domain.ip.IPv6;
 import org.calrissian.mango.types.encoders.simple.*;
@@ -118,6 +119,10 @@ public class SimpleTypeEncoders {
 
     public static TypeEncoder<EntityIdentifier, String> entityIdentifierEncoder() {
         return new EntityIdentifierEncoder();
+    }
+
+    public static TypeEncoder<EventIdentifier, String> eventIdentifierEncoder() {
+        return new EventIdentifierEncoder();
     }
 
     public static TypeEncoder<UnsignedInteger, String> unsignedIntegerEncoder() {

--- a/mango-core/src/main/java/org/calrissian/mango/types/encoders/AbstractEventIdentifierEncoder.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/encoders/AbstractEventIdentifierEncoder.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2013 The Calrissian Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.calrissian.mango.types.encoders;
+
+import org.calrissian.mango.domain.event.EventIdentifier;
+import org.calrissian.mango.types.TypeEncoder;
+
+import static org.calrissian.mango.types.encoders.AliasConstants.EVENT_IDENTIFIER_ALIAS;
+
+public abstract class AbstractEventIdentifierEncoder<U> implements TypeEncoder<EventIdentifier, U> {
+
+    @Override
+    public String getAlias() {
+        return EVENT_IDENTIFIER_ALIAS;
+    }
+
+    @Override
+    public Class<EventIdentifier> resolves() {
+        return EventIdentifier.class;
+    }
+}

--- a/mango-core/src/main/java/org/calrissian/mango/types/encoders/AliasConstants.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/encoders/AliasConstants.java
@@ -33,7 +33,8 @@ public class AliasConstants {
     public static String INET6_ALIAS = "inet6";
 
     //Mango types
-    public static String ENTITY_IDENTIFIER_ALIAS = "entityIndex";
+    public static String ENTITY_IDENTIFIER_ALIAS = "entityId";
+    public static String EVENT_IDENTIFIER_ALIAS = "eventId";
     public static String IPV4_ALIAS = "ipv4";
     public static String IPV6_ALIAS = "ipv6";
 

--- a/mango-core/src/main/java/org/calrissian/mango/types/encoders/lexi/DateReverseEncoder.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/encoders/lexi/DateReverseEncoder.java
@@ -25,16 +25,16 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class DateReverseEncoder extends AbstractDateEncoder<String> {
     private static final long serialVersionUID = 1L;
 
-    private static final LongEncoder longEncoder = new LongEncoder();
+    private static final LongReverseEncoder longEncoder = new LongReverseEncoder();
 
     @Override
     public String encode(Date value) {
         checkNotNull(value, "Null values are not allowed");
-        return longEncoder.encode(~value.getTime());
+        return longEncoder.encode(value.getTime());
     }
 
     @Override
     public Date decode(String value) {
-        return new Date(~longEncoder.decode(value));
+        return new Date(longEncoder.decode(value));
     }
 }

--- a/mango-core/src/main/java/org/calrissian/mango/types/encoders/lexi/EventIdentifierEncoder.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/encoders/lexi/EventIdentifierEncoder.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2013 The Calrissian Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.calrissian.mango.types.encoders.lexi;
+
+import org.calrissian.mango.domain.event.EventIdentifier;
+import org.calrissian.mango.types.encoders.AbstractEventIdentifierEncoder;
+import org.calrissian.mango.types.exception.TypeDecodingException;
+import org.calrissian.mango.types.exception.TypeEncodingException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.Long.parseLong;
+import static java.lang.String.format;
+
+public class EventIdentifierEncoder extends AbstractEventIdentifierEncoder<String> {
+    private static final long serialVersionUID = 1L;
+
+    private static final String SCHEME = "event://";
+    private static final LongEncoder longEncoder = new LongEncoder();
+
+    @Override
+    public String encode(EventIdentifier value) throws TypeEncodingException {
+        checkNotNull(value, "Null values are not allowed");
+        return format("%s%s#%s@%s", SCHEME, value.getType(), value.getId(), longEncoder.encode(value.getTimestamp()));
+    }
+
+    @Override
+    public EventIdentifier decode(String value) throws TypeDecodingException {
+        checkNotNull(value, "Null values are not allowed");
+        checkArgument(value.startsWith(SCHEME) && value.contains("#") && value.contains("@"), "The value is not a valid encoding");
+
+        String rel = value.substring(SCHEME.length(), value.length());
+        int idx = rel.indexOf('#');
+        int tsIdx = rel.lastIndexOf('@');
+        return new EventIdentifier(rel.substring(0, idx), rel.substring(idx + 1, tsIdx), longEncoder.decode(rel.substring(tsIdx + 1)));
+    }
+}

--- a/mango-core/src/main/java/org/calrissian/mango/types/encoders/simple/EventIdentifierEncoder.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/encoders/simple/EventIdentifierEncoder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2013 The Calrissian Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.calrissian.mango.types.encoders.simple;
+
+import org.calrissian.mango.domain.event.EventIdentifier;
+import org.calrissian.mango.types.encoders.AbstractEventIdentifierEncoder;
+import org.calrissian.mango.types.exception.TypeDecodingException;
+import org.calrissian.mango.types.exception.TypeEncodingException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.Long.parseLong;
+import static java.lang.String.format;
+
+public class EventIdentifierEncoder extends AbstractEventIdentifierEncoder<String> {
+    private static final long serialVersionUID = 1L;
+
+    private static final String SCHEME = "event://";
+
+    @Override
+    public String encode(EventIdentifier value) throws TypeEncodingException {
+        checkNotNull(value, "Null values are not allowed");
+        return format("%s%s#%s@%d", SCHEME, value.getType(), value.getId(), value.getTimestamp());
+    }
+
+    @Override
+    public EventIdentifier decode(String value) throws TypeDecodingException {
+        checkNotNull(value, "Null values are not allowed");
+        checkArgument(value.startsWith(SCHEME) && value.contains("#") && value.contains("@"), "The value is not a valid encoding");
+
+        String rel = value.substring(SCHEME.length(), value.length());
+        int idx = rel.indexOf('#');
+        int tsIdx = rel.lastIndexOf('@');
+        return new EventIdentifier(rel.substring(0, idx), rel.substring(idx + 1, tsIdx), parseLong(rel.substring(tsIdx + 1)));
+    }
+}

--- a/mango-core/src/test/java/org/calrissian/mango/types/LexiTypeEncodersTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/types/LexiTypeEncodersTest.java
@@ -18,6 +18,7 @@ package org.calrissian.mango.types;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.calrissian.mango.domain.entity.EntityIdentifier;
+import org.calrissian.mango.domain.event.EventIdentifier;
 import org.calrissian.mango.domain.ip.IPv4;
 import org.calrissian.mango.domain.ip.IPv6;
 import org.junit.Test;
@@ -65,6 +66,8 @@ public class LexiTypeEncodersTest {
         verifyBasicFunctionality(INET6_ALIAS, forIPv6String("::ffff:192.168.1.1"), inet6AddressEncoder());
         verifyBasicFunctionality(ENTITY_IDENTIFIER_ALIAS, new EntityIdentifier("type", "id"), entityIdentifierEncoder());
         verifyBasicFunctionality(ENTITY_IDENTIFIER_ALIAS, new EntityIdentifier("", ""), entityIdentifierEncoder());
+        verifyBasicFunctionality(EVENT_IDENTIFIER_ALIAS, new EventIdentifier("type", "id", Long.MAX_VALUE), eventIdentifierEncoder());
+        verifyBasicFunctionality(EVENT_IDENTIFIER_ALIAS, new EventIdentifier("", "", 0), eventIdentifierEncoder());
         verifyBasicFunctionality(UNSIGNEDINTEGER_ALIAS, UnsignedInteger.fromIntBits(3), unsignedIntegerEncoder());
         verifyBasicFunctionality(UNSIGNEDINTEGER_ALIAS, UnsignedInteger.MAX_VALUE, unsignedIntegerEncoder());
         verifyBasicFunctionality(UNSIGNEDLONG_ALIAS, UnsignedLong.fromLongBits(3), unsignedLongEncoder());
@@ -95,6 +98,8 @@ public class LexiTypeEncodersTest {
         verifyBasicFunctionality(INET6_ALIAS, forIPv6String("::ffff:192.168.1.1"), inet6AddressRevEncoder());
         verifyBasicFunctionality(ENTITY_IDENTIFIER_ALIAS, new EntityIdentifier("type", "id"), entityIdentifierRevEncoder());
         verifyBasicFunctionality(ENTITY_IDENTIFIER_ALIAS, new EntityIdentifier("", ""), entityIdentifierRevEncoder());
+        verifyBasicFunctionality(EVENT_IDENTIFIER_ALIAS, new EventIdentifier("type", "id", Long.MAX_VALUE), eventIdentifierRevEncoder());
+        verifyBasicFunctionality(EVENT_IDENTIFIER_ALIAS, new EventIdentifier("", "", 0), eventIdentifierRevEncoder());
         verifyBasicFunctionality(UNSIGNEDINTEGER_ALIAS, UnsignedInteger.fromIntBits(3), unsignedIntegerRevEncoder());
         verifyBasicFunctionality(UNSIGNEDINTEGER_ALIAS, UnsignedInteger.MAX_VALUE, unsignedIntegerRevEncoder());
         verifyBasicFunctionality(UNSIGNEDLONG_ALIAS, UnsignedLong.fromLongBits(3), unsignedLongRevEncoder());
@@ -156,6 +161,8 @@ public class LexiTypeEncodersTest {
         assertEquals("ffffffffffffffffffffffffffffffff", inet6AddressEncoder().encode(forIPv6String("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")));
 
         assertEquals("entity://type#id", entityIdentifierEncoder().encode(new EntityIdentifier("type", "id")));
+        assertEquals("event://type#id@ffffffffffffffff", eventIdentifierEncoder().encode(new EventIdentifier("type", "id", Long.MAX_VALUE)));
+
 
         assertEquals("00000003", unsignedIntegerEncoder().encode(UnsignedInteger.fromIntBits(3)));
         assertEquals("ffffffff", unsignedIntegerEncoder().encode(UnsignedInteger.MAX_VALUE));

--- a/mango-core/src/test/java/org/calrissian/mango/types/SimpleTypeEncodersTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/types/SimpleTypeEncodersTest.java
@@ -19,6 +19,7 @@ package org.calrissian.mango.types;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import org.calrissian.mango.domain.entity.EntityIdentifier;
+import org.calrissian.mango.domain.event.EventIdentifier;
 import org.calrissian.mango.domain.ip.IPv4;
 import org.calrissian.mango.domain.ip.IPv6;
 import org.junit.Test;
@@ -74,6 +75,8 @@ public class SimpleTypeEncodersTest {
         verifyBasicFunctionality(IPV6_ALIAS, IPv6.fromString("::ffff:192.168.1.1"), ipv6Encoder());
         verifyBasicFunctionality(ENTITY_IDENTIFIER_ALIAS, new EntityIdentifier("type", "id"), entityIdentifierEncoder());
         verifyBasicFunctionality(ENTITY_IDENTIFIER_ALIAS, new EntityIdentifier("", ""), entityIdentifierEncoder());
+        verifyBasicFunctionality(EVENT_IDENTIFIER_ALIAS, new EventIdentifier("type", "id", Long.MAX_VALUE), eventIdentifierEncoder());
+        verifyBasicFunctionality(EVENT_IDENTIFIER_ALIAS, new EventIdentifier("", "", 0), eventIdentifierEncoder());
         verifyBasicFunctionality(UNSIGNEDINTEGER_ALIAS, UnsignedInteger.fromIntBits(3), unsignedIntegerEncoder());
         verifyBasicFunctionality(UNSIGNEDINTEGER_ALIAS, UnsignedInteger.MAX_VALUE, unsignedIntegerEncoder());
         verifyBasicFunctionality(UNSIGNEDLONG_ALIAS, UnsignedLong.fromLongBits(3), unsignedLongEncoder());
@@ -108,6 +111,8 @@ public class SimpleTypeEncodersTest {
         assertEquals("85070591730234615847396907784232501249", bigIntegerEncoder().encode(BigInteger.valueOf(Long.MAX_VALUE).pow(2)));
 
         assertEquals("entity://type#id", entityIdentifierEncoder().encode(new EntityIdentifier("type", "id")));
+
+        assertEquals("event://type#id@9223372036854775807", eventIdentifierEncoder().encode(new EventIdentifier("type", "id", Long.MAX_VALUE)));
 
         assertEquals("192.168.1.1", ipv4Encoder().encode(IPv4.fromString("192.168.1.1")));
 


### PR DESCRIPTION
simply added type encoders for event idenifiers

format:
event//type#id@timestamp

For the lexi-type encoder, the timestamp is also lexicographically encoded so that an identifier with the same type and id will be ordered by timestamp.