### PR TITLE
Better logic around closing a Batcher.

### DIFF
--- a/mango-core/src/main/java/org/calrissian/mango/batch/AbstractBatcher.java
+++ b/mango-core/src/main/java/org/calrissian/mango/batch/AbstractBatcher.java
@@ -16,7 +16,9 @@
 package org.calrissian.mango.batch;
 
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -25,9 +27,11 @@ import java.util.logging.Logger;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Long.MAX_VALUE;
 import static java.lang.Thread.interrupted;
 import static java.util.Collections.unmodifiableCollection;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.logging.Level.SEVERE;
 
 /**
@@ -37,9 +41,7 @@ abstract class AbstractBatcher<T> implements Batcher<T> {
 
     private static final Logger logger = Logger.getLogger(AbstractBatcher.class.getName());
 
-
     private final ExecutorService batchService;
-    private final BatchRunnable batchRunnable;
     private Future<?> batchFuture;
 
     private final BlockingQueue<T> backingQueue;
@@ -54,7 +56,6 @@ abstract class AbstractBatcher<T> implements Batcher<T> {
         this.handler = handler;
 
         batchService = newSingleThreadExecutor();
-        batchRunnable = new BatchRunnable();
     }
 
     /**
@@ -66,7 +67,7 @@ abstract class AbstractBatcher<T> implements Batcher<T> {
      * To be called after construction of any subclass to instantiate the batching thread.
      */
     protected AbstractBatcher<T> start() {
-        batchFuture = batchService.submit(batchRunnable);
+        batchFuture = batchService.submit(new BatchRunnable());
         return this;
     }
 
@@ -106,16 +107,41 @@ abstract class AbstractBatcher<T> implements Batcher<T> {
     }
 
     /**
-     * {@inheritDoc}
+     * Used to shutdown the batching thread in case of an error or user requested close.
      */
-    @Override
-    public void close() {
+    private void closeRunnable() {
         isClosed = true;
         //Force an interrupt on running thread and shutdown executor cleanly.
         batchFuture.cancel(true);
         batchService.shutdown();
+    }
 
-        handler.shutdownNow();
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() {
+        closeRunnable();
+        try {
+            batchService.awaitTermination(MAX_VALUE, MILLISECONDS);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        handler.shutdown();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<T> closeAndFlush() {
+        close();
+        //Must wait until after close to drain
+        ArrayList<T> remaining = new ArrayList<>();
+        backingQueue.drainTo(remaining);
+
+        return remaining;
     }
 
     private class BatchRunnable implements Runnable {
@@ -123,20 +149,12 @@ abstract class AbstractBatcher<T> implements Batcher<T> {
         @Override
         public void run() {
             try {
-                while (!isClosed && !interrupted() && !handler.isShutdown()) {
-
-
-                    final Collection<T> batch;
-                    try {
-                        batch = generateBatch(backingQueue);
-                    } catch (InterruptedException e) {
-                        //When shut down it is expecting an interrupt, so simply exit cleanly.
-                        break;
-                    }
+                while (!isClosed && !handler.isShutdown() && !interrupted()) {
+                    //Each batcher should have handled its
+                    final Collection<T> batch = generateBatch(backingQueue);
 
                     //Good faith handler shutdown check
                     if (!batch.isEmpty() && !handler.isShutdown()) {
-
                         try {
                             handler.execute(new Runnable() {
                                 @Override
@@ -147,7 +165,7 @@ abstract class AbstractBatcher<T> implements Batcher<T> {
                         } catch (Exception e) {
                             //Handler threw exception.  Close the batcher and exit cleanly.
                             logger.log(SEVERE, "Encountered exception sending to batch listener.  Closing the batcher", e);
-                            close();
+                            closeRunnable();
                         }
                     }
                 }
@@ -155,7 +173,7 @@ abstract class AbstractBatcher<T> implements Batcher<T> {
                 //Unknown exception
                 try {
                     logger.log(SEVERE, "Batcher should not have throw exception.  Closing the batcher", e);
-                    close();
+                    closeRunnable();
                 } catch (Throwable e2) {
                     //Do nothing, just exit cleanly
                 }

--- a/mango-core/src/main/java/org/calrissian/mango/batch/BatchListener.java
+++ b/mango-core/src/main/java/org/calrissian/mango/batch/BatchListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 The Calrissian Authors
+ * Copyright (C) 2016 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,11 @@ package org.calrissian.mango.batch;
 
 import java.util.Collection;
 
+/**
+ * Listens for new batches from a {@link Batcher}. Each call to {@code onBatch} is executed on a separate thread and
+ * therefore the BatchListener is responsible for managing its own thread safety.
+ * @param <T>
+ */
 public interface BatchListener<T> {
 
     /**

--- a/mango-core/src/main/java/org/calrissian/mango/batch/Batcher.java
+++ b/mango-core/src/main/java/org/calrissian/mango/batch/Batcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 The Calrissian Authors
+ * Copyright (C) 2016 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,15 @@ import java.io.Closeable;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Batches items into collections. Items can be added to a batcher to be included in a batch. To construct a new Batcher,
+ * use {@link BatcherBuilder} to generate a configured Batcher.
+ * <p>
+ * Batchers utilize a queue to buffer items while batches are being constructed. When a buffer size if provided, callers
+ * can be prevented from overwhelming the queue with data. Use the appropriate {@code add} method to manage a full
+ * queue.
+ * </p>
+ */
 public interface Batcher<T> extends Closeable {
 
     /**
@@ -44,12 +53,13 @@ public interface Batcher<T> extends Closeable {
     boolean addOrWait(T item) throws InterruptedException;
 
     /**
-     * Closes the underlying batcher and flushes the remaining elements in the batch queue to a list.
+     * Closes the underlying batcher and flushes the remaining elements in the queue to a list. This blocks until all
+     * submitted batches have been processed.
      */
     List<T> closeAndFlush();
 
     /**
-     * Closes the underlying batcher and any .
+     * Closes the underlying batcher. This blocks until all submitted batches have been processed.
      */
     @Override
     void close();

--- a/mango-core/src/main/java/org/calrissian/mango/batch/Batcher.java
+++ b/mango-core/src/main/java/org/calrissian/mango/batch/Batcher.java
@@ -16,6 +16,7 @@
 package org.calrissian.mango.batch;
 
 import java.io.Closeable;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public interface Batcher<T> extends Closeable {
@@ -43,7 +44,12 @@ public interface Batcher<T> extends Closeable {
     boolean addOrWait(T item) throws InterruptedException;
 
     /**
-     * {@inheritDoc}
+     * Closes the underlying batcher and flushes the remaining elements in the batch queue to a list.
+     */
+    List<T> closeAndFlush();
+
+    /**
+     * Closes the underlying batcher and any .
      */
     @Override
     void close();

--- a/mango-core/src/main/java/org/calrissian/mango/batch/BatcherBuilder.java
+++ b/mango-core/src/main/java/org/calrissian/mango/batch/BatcherBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 The Calrissian Authors
+ * Copyright (C) 2016 The Calrissian Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,11 +61,11 @@ public final class BatcherBuilder {
 
     /**
      * Add a max time component for a batcher.  If specified a batcher will call the {@link BatchListener}
-     * as sppon as the time bound has been exceeded.
+     * as soon as the time bound has been exceeded.
      *
      * NOTE: This interval is the time since successfully sending the last batch to the batchlistener.  This means
      * that if a blocking {@link BatcherBuilder#listenerService(ExecutorService)} is used then the time interval will not
-     * restart until it has been successfully handed of to the {@link BatcherBuilder#listenerService(ExecutorService)}.
+     * restart until it has been successfully handed off to the {@link BatcherBuilder#listenerService(ExecutorService)}.
      */
     public BatcherBuilder timeBound(long time, TimeUnit timeUnit) {
         checkState(this.interval == UNSET_INT, "Max time already set");

--- a/mango-core/src/test/java/org/calrissian/mango/batch/BatcherTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/batch/BatcherTest.java
@@ -47,10 +47,10 @@ public class BatcherTest {
 
     @Test
     public void sizeBatcherTest() throws InterruptedException {
-        TestListenter<Integer> listenter = new TestListenter<>();
+        TestListenter<Integer> listener = new TestListenter<>();
         final Batcher<Integer> batcher = BatcherBuilder.create()
                 .sizeBound(100)
-                .build(listenter);
+                .build(listener);
 
         CountDownLatch start = new CountDownLatch(1);
         CountDownLatch done = setupProducers(batcher, start, 10, 100);
@@ -60,19 +60,19 @@ public class BatcherTest {
         sleep(40);
         batcher.close();
 
-        assertEquals(1000, listenter.getCount());
-        assertTrue(listenter.getNumBatches() >= 10);
-        for (Collection<Integer> batch : listenter.getBatches()) {
+        assertEquals(1000, listener.getCount());
+        assertTrue(listener.getNumBatches() >= 10);
+        for (Collection<Integer> batch : listener.getBatches()) {
             assertEquals(100, batch.size());
         }
     }
 
     @Test
     public void sizeBatcherNonFullBatchTest() throws InterruptedException {
-        TestListenter<Integer> listenter = new TestListenter<>();
+        TestListenter<Integer> listener = new TestListenter<>();
         final Batcher<Integer> batcher = BatcherBuilder.create()
                 .sizeBound(100)
-                .build(listenter);
+                .build(listener);
 
         CountDownLatch start = new CountDownLatch(1);
         CountDownLatch done = setupProducers(batcher, start, 10, 102); //don't align with batch size
@@ -83,10 +83,10 @@ public class BatcherTest {
         batcher.close();
         sleep(40); //wait for handler thread after close to process leftover batch.
 
-        assertEquals(1020, listenter.getCount());
-        assertTrue(listenter.getNumBatches() == 11);
+        assertEquals(1020, listener.getCount());
+        assertTrue(listener.getNumBatches() == 11);
         int count = 0;
-        for (Collection<Integer> batch : listenter.getBatches()) {
+        for (Collection<Integer> batch : listener.getBatches()) {
             if (count == 10) {
                 assertEquals(20, batch.size());
             } else {
@@ -98,10 +98,10 @@ public class BatcherTest {
 
     @Test
     public void timeBatcherTest() throws InterruptedException {
-        TestListenter<Integer> listenter = new TestListenter<>();
+        TestListenter<Integer> listener = new TestListenter<>();
         final Batcher<Integer> batcher = BatcherBuilder.create()
                 .timeBound(10, MILLISECONDS)
-                .build(listenter);
+                .build(listener);
 
         CountDownLatch start = new CountDownLatch(1);
         CountDownLatch done = setupProducers(batcher, start, 10, 100);
@@ -112,20 +112,20 @@ public class BatcherTest {
         sleep(40);
         batcher.close();
 
-        assertEquals(1000, listenter.getCount());
-        assertTrue(listenter.getNumBatches() >= 1);
-        for (Collection<Integer> batch : listenter.getBatches()) {
+        assertEquals(1000, listener.getCount());
+        assertTrue(listener.getNumBatches() >= 1);
+        for (Collection<Integer> batch : listener.getBatches()) {
             assertTrue(!batch.isEmpty());
         }
     }
 
     @Test
     public void sizeAndTimeBatcherTest() throws InterruptedException {
-        TestListenter<Integer> listenter = new TestListenter<>();
+        TestListenter<Integer> listener = new TestListenter<>();
         final Batcher<Integer> batcher = BatcherBuilder.create()
                 .sizeBound(100)
                 .timeBound(10, MILLISECONDS)
-                .build(listenter);
+                .build(listener);
 
         CountDownLatch start = new CountDownLatch(1);
         CountDownLatch done = setupProducers(batcher, start, 10, 100);
@@ -136,9 +136,9 @@ public class BatcherTest {
         sleep(40);
         batcher.close();
 
-        assertEquals(1000, listenter.getCount());
-        assertTrue(listenter.getNumBatches() >= 10);
-        for (Collection<Integer> batch : listenter.getBatches()) {
+        assertEquals(1000, listener.getCount());
+        assertTrue(listener.getNumBatches() >= 10);
+        for (Collection<Integer> batch : listener.getBatches()) {
             assertTrue(!batch.isEmpty());
             assertTrue(batch.size() <= 100);
         }


### PR DESCRIPTION
The biggest change here is to allow a user to guarantee that all data put into a Batcher can either be handled or recovered.

While closing, the batcher will now send the final batch to the handler.  Additionally, the close method will wait until all batches have been processed.  In the event that there is data left in the processing queue that didn't get processed in a batch, a new closeAndFlush() method was added to retrieved all unprocessed items.