### PR TITLE
Give more helpful error message when an invalid alias is encountered

### DIFF
--- a/mango-core/src/main/java/org/calrissian/mango/types/TypeRegistry.java
+++ b/mango-core/src/main/java/org/calrissian/mango/types/TypeRegistry.java
@@ -117,7 +117,7 @@ public class TypeRegistry<U> implements Serializable {
         if (encoder != null)
             return encoder.decode(value);
 
-        throw new TypeDecodingException("An unknown alias [" + value + "] was encountered");
+        throw new TypeDecodingException("An unknown alias [" + alias + "] was encountered while decoding value [" + value + "]. Valid aliases are " + String.join(", ", aliasMapping.keySet()));
     }
 
     /**


### PR DESCRIPTION
The current error message when an invalid alias is passed in is misleading. I revised it to make it more user-friendly.