### PR TITLE
Fix bug in CIDR parsing code.

### DIFF
--- a/mango-core/src/main/java/org/calrissian/mango/net/MoreInetAddresses.java
+++ b/mango-core/src/main/java/org/calrissian/mango/net/MoreInetAddresses.java
@@ -346,7 +346,7 @@ public class MoreInetAddresses {
                     network[i] = bytes[i];
                     broadcast[i] = bytes[i];
                 } else if (remainingBits > 0) {
-                    int byteMask = -1 << remainingBits;
+                    int byteMask = -1 << (8 - remainingBits);
                     network [i] = (byte) (bytes[i] & byteMask);
                     broadcast [i] = (byte) (bytes[i] | ~byteMask);
                 } else {

--- a/mango-core/src/test/java/org/calrissian/mango/net/MoreInetAddressesTest.java
+++ b/mango-core/src/test/java/org/calrissian/mango/net/MoreInetAddressesTest.java
@@ -294,6 +294,12 @@ public class MoreInetAddressesTest {
         assertEquals("0.0.0.0", toAddrString(cidr.getNetwork()));
         assertEquals("0.0.15.255", toAddrString(cidr.getBroadcast()));
 
+        cidr = MoreInetAddresses.parseCIDR("123.45.67.0/21");
+        assertTrue(cidr.getNetwork() instanceof Inet4Address);
+        assertEquals("123.45.64.0", toAddrString(cidr.getNetwork()));
+        assertEquals("123.45.71.255", toAddrString(cidr.getBroadcast()));
+
+
         cidr = MoreInetAddresses.parseCIDR("1.2.3.4/32");
         assertTrue(cidr.getNetwork() instanceof Inet4Address);
         assertEquals("1.2.3.4", toAddrString(cidr.getNetwork()));


### PR DESCRIPTION
See also https://www.ipaddressguide.com/cidr to test. Essentially, the existing code keeps the wrong number of bits, but because the test cases only had netmask % 8 == 4, it was missed.